### PR TITLE
Add Makefile for building the artifact and downloading dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,7 @@ DETECTED_OS := $(shell uname -s)
 DEP_BIN_GIT := https://github.com/golang/dep/releases/download/v0.4.1/dep-$(DETECTED_OS)-amd64
 BIN := etcdadm
 PACKAGE_GOPATH := /go/src/github.com/platform9/$(BIN)
-DEP_TEST=$(shell which dep)
-
-ifeq ($(DEP_TEST),)
-	DEP_BIN := $(CWD)/bin/dep
-else
-	DEP_BIN := $(DEP_TEST)
-endif
+DEP_BIN := $(CWD)/bin/dep
 
 .PHONY: container-build default ensure
 


### PR DESCRIPTION
The artifact will be built on a golang:1.10 container.
Since this project does not include vendored packages, we're
adding a target to install dep ensure.