### PR TITLE
Added download only functionality that downloads etcd & etcdctl binary

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/platform9/etcdadm/apis"
+	"github.com/platform9/etcdadm/binary"
+	"github.com/platform9/etcdadm/constants"
+	"github.com/spf13/cobra"
+)
+
+var downloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download etcd binary",
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		err = apis.SetInitDynamicDefaults(&etcdAdmConfig)
+		if err != nil {
+			log.Fatalf("[defaults] Error: %s", err)
+		}
+		err = binary.EnsureInstalled(etcdAdmConfig.ReleaseURL, etcdAdmConfig.Version, etcdAdmConfig.InstallDir)
+		if err != nil {
+			log.Fatalf("[install] Error: %s", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(downloadCmd)
+
+	downloadCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallBaseDir, "install-base-dir", constants.DefaultInstallBaseDir, "install base directory")
+	downloadCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
+	downloadCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
+}

--- a/util/etcdclient.go
+++ b/util/etcdclient.go
@@ -54,6 +54,11 @@ func AddSelfToEtcdCluster(endpoint string, etcdAdmConfig *apis.EtcdAdmConfig) (*
 func RemoveSelfFromEtcdCluster(etcdAdmConfig *apis.EtcdAdmConfig) error {
 	etcdEndpoint := fmt.Sprintf("https://%s:%d", constants.DefaultLoopbackHost, constants.DefaultClientPort)
 	cli, err := getEtcdClientV3(etcdEndpoint, etcdAdmConfig)
+	if err != nil {
+		log.Print(err)
+		return err
+	}
+	defer cli.Close()
 	apis.DefaultAdvertisePeerURLs(etcdAdmConfig)
 	members, err := MemberList(etcdEndpoint, etcdAdmConfig)
 	// Find the current member from the list and extract it's ID


### PR DESCRIPTION
Addresses Issue: https://github.com/platform9/etcdadm/issues/5

Also fixed an issue wih etcdadm reset. We want to do best-effort reset
rather than fail on first failure