### PR TITLE
Updated directory structure and have versioned names

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -20,7 +20,6 @@ import (
 type EtcdAdmConfig struct {
 	Version         string
 	ReleaseURL      string
-	InstallBaseDir  string
 	CertificatesDir string
 
 	DownloadConnectTimeout time.Duration
@@ -139,11 +138,10 @@ func setDynamicDefaults(cfg *EtcdAdmConfig) error {
 		cfg.Name = name
 	}
 
-	cfg.InstallDir = filepath.Join(cfg.InstallBaseDir, fmt.Sprintf("etcd-v%s", cfg.Version))
-	cfg.CacheDir = filepath.Join(constants.DefaultCacheBaseDir, fmt.Sprintf("etcd-v%s", cfg.Version))
+	cfg.CacheDir = filepath.Join(constants.DefaultCacheBaseDir, "etcd", fmt.Sprintf("v%s", cfg.Version))
 	cfg.EtcdExecutable = filepath.Join(cfg.InstallDir, "etcd")
 	cfg.EtcdctlExecutable = filepath.Join(cfg.InstallDir, "etcdctl")
-	cfg.EtcdctlShellWrapper = filepath.Join(cfg.InstallBaseDir, "etcdctl.sh")
+	cfg.EtcdctlShellWrapper = filepath.Join(cfg.InstallDir, "etcdctl.sh")
 
 	cfg.GOMAXPROCS = runtime.NumCPU()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -23,7 +23,7 @@ var initCmd = &cobra.Command{
 			log.Fatalf("[defaults] Error: %s", err)
 		}
 		// etcd binaries installation
-		inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallBaseDir, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
+		inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
 		if err != nil {
 			log.Fatalf("[install] Artifact could not be installed from cache: %s", err)
 		}
@@ -33,7 +33,7 @@ var initCmd = &cobra.Command{
 				log.Fatalf("[install] Unable to fetch artifact from upstream: %s", err)
 			}
 			// Try installing binaries from cache now
-			inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallBaseDir, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
+			inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
 			if err != nil {
 				log.Fatalf("[install] Artifact could not be installed from cache: %s", err)
 			}
@@ -87,7 +87,7 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
-	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallBaseDir, "install-base-dir", constants.DefaultInstallBaseDir, "install base directory")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Snapshot, "snapshot", "", "Etcd v3 snapshot file used to initialize member")
 	initCmd.PersistentFlags().BoolVar(&etcdAdmConfig.SkipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 	initCmd.PersistentFlags().DurationVar(&etcdAdmConfig.DownloadConnectTimeout, "download-connect-timeout", constants.DefaultDownloadConnectTimeout, "Maximum time in seconds that you allow the connection to the server to take.")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -39,7 +39,7 @@ var joinCmd = &cobra.Command{
 			log.Fatalf("[defaults] Error: %s", err)
 		}
 		// etcd binaries installation
-		inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallBaseDir, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
+		inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
 		if err != nil {
 			log.Fatalf("[install] Artifact could not be installed from cache: %s", err)
 		}
@@ -49,7 +49,7 @@ var joinCmd = &cobra.Command{
 				log.Fatalf("[install] Unable to fetch artifact from upstream: %s", err)
 			}
 			// Try installing binaries from cache now
-			inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallBaseDir, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
+			inCache, err := binary.InstallFromCache(etcdAdmConfig.Version, etcdAdmConfig.InstallDir, etcdAdmConfig.CacheDir)
 			if err != nil {
 				log.Fatalf("[install] Artifact could not be installed from cache: %s", err)
 			}
@@ -116,5 +116,5 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
-	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallBaseDir, "install-base-dir", constants.DefaultInstallBaseDir, "install base directory")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -54,7 +54,7 @@ var resetCmd = &cobra.Command{
 			log.Print(err)
 		}
 		// Remove binaries
-		if err := binary.Uninstall(etcdAdmConfig.Version, etcdAdmConfig.InstallBaseDir, etcdAdmConfig.InstallDir); err != nil {
+		if err := binary.Uninstall(etcdAdmConfig.Version, etcdAdmConfig.InstallDir); err != nil {
 			log.Printf("[binaries] Unable to uninstall binaries: %v", err)
 		}
 		if err = os.Remove(etcdAdmConfig.EtcdctlShellWrapper); err != nil {
@@ -67,6 +67,6 @@ var resetCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(resetCmd)
 	resetCmd.Flags().BoolVar(&skipRemoveMember, "skip-remove-member", constants.DefaultSkipRemoveMember, "Use skip-remove-member flag to skip the process of removing member from etcd cluster but clean everything else.")
-	resetCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallBaseDir, "install-base-dir", constants.DefaultInstallBaseDir, "install base directory")
+	resetCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	resetCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -4,8 +4,8 @@ import "time"
 
 // Command-line flag defaults
 const (
-	DefaultVersion        = "3.3.8"
-	DefaultInstallBaseDir = "/opt/bin/"
+	DefaultVersion    = "3.3.8"
+	DefaultInstallDir = "/opt/bin/"
 
 	DefaultReleaseURL     = "https://github.com/coreos/etcd/releases/download"
 	DefaultBindAddressv4  = "0.0.0.0"

--- a/util/filesystem.go
+++ b/util/filesystem.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"os/exec"
 )
 
 // FileExists checks whether the file exists
@@ -13,4 +14,12 @@ func FileExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// CopyFile copies file from src to dest
+func CopyFile(srcFile, destFile string) error {
+	if err := exec.Command("cp", "-f", srcFile, destFile).Run(); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Updated `/var/cache` to have a consistent format. 
Updated directory names to have versions, to allow multiple installations to coexist
Have `/opt/bin` to have actual binaries and not symlinks (as we now have directories with versions in `/var/cache`)

Also change the directory names for other binaries to follow the same pattern of
`/var/cache/<parent-tool>/<tool>/<tool-version>/<tool-binary>` (by parent tool we mean the one which uses the tool, e.g. ssh-provider is the parent tool for nodeadm, while nodeadm is the parent tool for kubernetes)

#### contents of `/var/cache`
```
coreos-puneet-199-10-105-16-14platform9 cache # find nodeadm/
nodeadm/
nodeadm/kubernetes
nodeadm/kubernetes/v1.10.4
nodeadm/kubernetes/v1.10.4/10-kubeadm.conf
nodeadm/kubernetes/v1.10.4/kubeadm
nodeadm/kubernetes/v1.10.4/kubelet.service
nodeadm/kubernetes/v1.10.4/kubectl
nodeadm/kubernetes/v1.10.4/kubelet
nodeadm/cni
nodeadm/cni/v0.6.0
nodeadm/cni/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
nodeadm/images
nodeadm/images/80cc5ea4b547abe174d7550b82825ace40769e977cde90495df3427b3a0f4e75.tar
nodeadm/images/c2ce1ffb51ed60c54057f53b8756231f5b4b792ce04113c6755339a1beb25943.tar
...
nodeadm/flannel
nodeadm/flannel/v0.10.0
nodeadm/flannel/v0.10.0/kube-flannel.yml

coreos-puneet-199-10-105-16-14platform9 cache # find etcdadm/
etcdadm/
etcdadm/etcd
etcdadm/etcd/v3.3.8
etcdadm/etcd/v3.3.8/etcd-v3.3.8-linux-amd64.tar.gz

coreos-puneet-199-10-105-16-14platform9 cache # find ssh-provider/
ssh-provider/
ssh-provider/nodeadm
ssh-provider/nodeadm/v.0.0.1-alpha
ssh-provider/nodeadm/v.0.0.1-alpha/nodeadm
ssh-provider/etcdadm
ssh-provider/etcdadm/v.0.0.1-alpha
ssh-provider/etcdadm/v.0.0.1-alpha/etcdadm
```
#### contents of `/opt/bin` 
```
coreos-puneet-199-10-105-16-14platform9 bin # ls
cctl  conf  etcd  etcdadm  etcdctl  exporter  kubeadm  kubectl  kubelet  nodeadm

```