### PR TITLE
Fix group name typos and clean up OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@
 aliases:
   sig-cluster-lifecycle-leads:
     - luxas
-    - roberthbailey
     - timothysc
   etcdadm-admins:
     - dlipovetsky

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,9 +5,9 @@ aliases:
     - luxas
     - roberthbailey
     - timothysc
-  etcdadmin-admins:
+  etcdadm-admins:
     - dlipovetsky
     - justinsb
-  etcdadmin-maintainers:
+  etcdadm-maintainers:
     - dlipovetsky
     - justinsb


### PR DESCRIPTION
Typos happen when you approve your own PR :frowning_face: 

Thanks to @sarun87 for spotting the typos!

/assign @justinsb 