### PR TITLE
fix #77: add `--listen-address` and --advertise-address`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Etcdadm must be run on the machine that is being added or removed. As a conseque
 On its own, etcdadm does not automate cluster operation, but a cluster orchestrator can delegate all the above tasks to etcdadm.
 
 <a name="questions"></a>
+
+## Options
+
+*  `--listen-address`, `--advertise-address`: specify an IP if you'd like something different than the auto-discovery. Regardless of this, you can also specify an alternative advertised address (for a floating IP for example).
+
 ## Questions?
 
 For more information reach out to [etcdadm slack channel](https://kubernetes.slack.com/messages/CEM0AT9GW)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -155,6 +155,8 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Snapshot, "snapshot", "", "Etcd v3 snapshot file used to initialize member")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ListenAddress, "listen-address", "", "IP to bind to")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.AdvertiseAddress, "advertise-address", "", "IP to advertise")
 	initCmd.PersistentFlags().BoolVar(&etcdAdmConfig.SkipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 	initCmd.PersistentFlags().DurationVar(&etcdAdmConfig.DownloadConnectTimeout, "download-connect-timeout", constants.DefaultDownloadConnectTimeout, "Maximum time in seconds that you allow the connection to the server to take.")
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -201,4 +201,6 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ListenAddress, "listen-address", "", "IP to bind to")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.AdvertiseAddress, "advertise-address", "", "IP to advertise")
 }


### PR DESCRIPTION
This commit add two options to configure etcd to bind on a specific address or to advertise a specific address, locally assigned or not.