### PR TITLE
Implement init system package to adapter different OS and mock tests

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/etcdadm/certs"
 	"sigs.k8s.io/etcdadm/constants"
 	"sigs.k8s.io/etcdadm/etcd"
+	"sigs.k8s.io/etcdadm/initsystem"
 	log "sigs.k8s.io/etcdadm/pkg/logrus"
 	"sigs.k8s.io/etcdadm/service"
 	"sigs.k8s.io/etcdadm/util"
@@ -42,22 +43,27 @@ var initCmd = &cobra.Command{
 			log.Fatalf("[defaults] Error: %s", err)
 		}
 
-		active, err := service.Active(constants.UnitFileBaseName)
+		initSystem, err := initsystem.GetInitSystem()
+		if err != nil {
+			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
+		}
+
+		active, err := initSystem.IsActive(constants.UnitFileBaseName)
 		if err != nil {
 			log.Fatalf("[start] Error checking if etcd service is active: %s", err)
 		}
 		if active {
-			if err := service.Stop(constants.UnitFileBaseName); err != nil {
+			if err := initSystem.Stop(constants.UnitFileBaseName); err != nil {
 				log.Fatalf("[start] Error stopping existing etcd service: %s", err)
 			}
 		}
 
-		enabled, err := service.Enabled(constants.UnitFileBaseName)
+		enabled, err := initSystem.IsEnabled(constants.UnitFileBaseName)
 		if err != nil {
 			log.Fatalf("[install] Error checking if etcd service is enabled: %s", err)
 		}
 		if enabled {
-			if err := service.Disable(constants.UnitFileBaseName); err != nil {
+			if err := initSystem.Disable(constants.UnitFileBaseName); err != nil {
 				log.Fatalf("[install] Error disabling existing etcd service: %s", err)
 			}
 		}
@@ -112,7 +118,7 @@ var initCmd = &cobra.Command{
 		if err = service.WriteUnitFile(&etcdAdmConfig); err != nil {
 			log.Fatalf("[configure] Error: %s", err)
 		}
-		if err = service.EnableAndStartService(constants.UnitFileBaseName); err != nil {
+		if err = initSystem.EnableAndStartService(constants.UnitFileBaseName); err != nil {
 			log.Fatalf("[start] Error: %s", err)
 		}
 		if err = service.WriteEtcdctlEnvFile(&etcdAdmConfig); err != nil {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/etcdadm/binary"
 	"sigs.k8s.io/etcdadm/constants"
 	"sigs.k8s.io/etcdadm/etcd"
-	"sigs.k8s.io/etcdadm/service"
+	"sigs.k8s.io/etcdadm/initsystem"
 )
 
 var skipRemoveMember bool
@@ -44,7 +44,12 @@ var resetCmd = &cobra.Command{
 			log.Fatalf("[defaults] Error: %s", err)
 		}
 
-		active, err := service.Active(constants.UnitFileBaseName)
+		initSystem, err := initsystem.GetInitSystem()
+		if err != nil {
+			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
+		}
+
+		active, err := initSystem.IsActive(constants.UnitFileBaseName)
 		if err != nil {
 			log.Fatalf("[reset] Error checking if etcd service is active: %s", err)
 		}
@@ -86,16 +91,16 @@ var resetCmd = &cobra.Command{
 				}
 			}
 			// Disable etcd service
-			if err := service.Stop(constants.UnitFileBaseName); err != nil {
+			if err := initSystem.Stop(constants.UnitFileBaseName); err != nil {
 				log.Fatalf("[reset] Error stopping existing etcd service: %s", err)
 			}
 		}
-		enabled, err := service.Enabled(constants.UnitFileBaseName)
+		enabled, err := initSystem.IsEnabled(constants.UnitFileBaseName)
 		if err != nil {
 			log.Fatalf("[reset] Error checking if etcd service is enabled: %s", err)
 		}
 		if enabled {
-			if err := service.Disable(constants.UnitFileBaseName); err != nil {
+			if err := initSystem.Disable(constants.UnitFileBaseName); err != nil {
 				log.Fatalf("[reset] Error disabling existing etcd service: %s", err)
 			}
 		}

--- a/initsystem/initsystem.go
+++ b/initsystem/initsystem.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initsystem
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// InitSystem is the interface that describe behaviors of an init system
+type InitSystem interface {
+	Start(service string) error
+	Stop(service string) error
+	Enable(service string) error
+	Disable(service string) error
+	IsActive(service string) (bool, error)
+	IsEnabled(service string) (bool, error)
+	EnableAndStartService(service string) error
+	DisableAndStopService(service string) error
+}
+
+// GetInitSystem returns an InitSystem for the current system, or error
+// if we cannot detect a supported init system.
+func GetInitSystem() (InitSystem, error) {
+	_, err := exec.LookPath("systemctl")
+	if err == nil {
+		return &SystemdInitSystem{}, nil
+	}
+
+	return nil, fmt.Errorf("systemd not detected; ensure that `systemctl` is in the PATH")
+}

--- a/initsystem/systemd.go
+++ b/initsystem/systemd.go
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+package initsystem
 
 import (
 	"fmt"
 	"os/exec"
 )
 
-func reloadSystemd() error {
+// SystemdInitSystem defines systemd init system
+type SystemdInitSystem struct{}
+
+func (s SystemdInitSystem) reloadSystemd() error {
 	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %v", err)
 	}
@@ -29,9 +32,9 @@ func reloadSystemd() error {
 }
 
 // Start a service
-func Start(service string) error {
+func (s SystemdInitSystem) Start(service string) error {
 	// Before we try to start any service, make sure that systemd is ready
-	if err := reloadSystemd(); err != nil {
+	if err := s.reloadSystemd(); err != nil {
 		return err
 	}
 	args := []string{"start", service}
@@ -42,9 +45,9 @@ func Start(service string) error {
 }
 
 // Stop a service
-func Stop(service string) error {
+func (s SystemdInitSystem) Stop(service string) error {
 	// Before we try to start any service, make sure that systemd is ready
-	if err := reloadSystemd(); err != nil {
+	if err := s.reloadSystemd(); err != nil {
 		return err
 	}
 	args := []string{"stop", service}
@@ -55,9 +58,9 @@ func Stop(service string) error {
 }
 
 // Enable a service
-func Enable(service string) error {
+func (s SystemdInitSystem) Enable(service string) error {
 	// Before we try to enable any service, make sure that systemd is ready
-	if err := reloadSystemd(); err != nil {
+	if err := s.reloadSystemd(); err != nil {
 		return err
 	}
 	args := []string{"enable", service}
@@ -68,9 +71,9 @@ func Enable(service string) error {
 }
 
 // Disable a service
-func Disable(service string) error {
+func (s SystemdInitSystem) Disable(service string) error {
 	// Before we try to disable any service, make sure that systemd is ready
-	if err := reloadSystemd(); err != nil {
+	if err := s.reloadSystemd(); err != nil {
 		return err
 	}
 	args := []string{"disable", service}
@@ -81,23 +84,23 @@ func Disable(service string) error {
 }
 
 // EnableAndStartService enables and starts the etcd service
-func EnableAndStartService(service string) error {
-	if err := Enable(service); err != nil {
+func (s SystemdInitSystem) EnableAndStartService(service string) error {
+	if err := s.Enable(service); err != nil {
 		return err
 	}
-	return Start(service)
+	return s.Start(service)
 }
 
 // DisableAndStopService disables and stops the etcd service
-func DisableAndStopService(service string) error {
-	if err := Disable(service); err != nil {
+func (s SystemdInitSystem) DisableAndStopService(service string) error {
+	if err := s.Disable(service); err != nil {
 		return err
 	}
-	return Stop(service)
+	return s.Stop(service)
 }
 
-// Active checks if the systemd unit is active
-func Active(service string) (bool, error) {
+// IsActive checks if the systemd unit is active
+func (s SystemdInitSystem) IsActive(service string) (bool, error) {
 	args := []string{"is-active", service}
 	if err := exec.Command("systemctl", args...).Run(); err != nil {
 		switch v := err.(type) {
@@ -112,8 +115,8 @@ func Active(service string) (bool, error) {
 	return true, nil
 }
 
-// Enabled checks if the systemd unit is enabled
-func Enabled(service string) (bool, error) {
+// IsEnabled checks if the systemd unit is enabled
+func (s SystemdInitSystem) IsEnabled(service string) (bool, error) {
 	args := []string{"is-enabled", service}
 	if err := exec.Command("systemctl", args...).Run(); err != nil {
 		switch v := err.(type) {


### PR DESCRIPTION
Implement issue https://github.com/kubernetes-sigs/etcdadm/issues/99.
Create new `initsystem` package similar to kubeadm https://github.com/kubernetes/kubernetes/tree/master/cmd/kubeadm/app/util/initsystem .

This is the first commit, i want to confirm if there is problem with this implementation, if no, i will continue.

Example code:

```go
initSystem, err := initsystem.GetInitSystem()
if err != nil {
	log.Fatalf("[initsystem] Error detect the init system: %s", err)
}

active, err := initSystem.IsActive("etcd.service")
if err != nil {
	log.Fatalf("[start] Error checking if etcd service is active: %s", err)
}
```