### PR TITLE
add --disk-priorities for support etcd tuning configuration

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -61,6 +61,7 @@ type EtcdAdmConfig struct {
 	EtcdctlExecutable   string
 	EtcdctlEnvFile      string
 	EtcdctlShellWrapper string
+	EtcdDiskPriorities  []string
 
 	InitialAdvertisePeerURLs URLList
 	ListenPeerURLs           URLList

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -155,4 +155,5 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Snapshot, "snapshot", "", "Etcd v3 snapshot file used to initialize member")
 	initCmd.PersistentFlags().BoolVar(&etcdAdmConfig.SkipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 	initCmd.PersistentFlags().DurationVar(&etcdAdmConfig.DownloadConnectTimeout, "download-connect-timeout", constants.DefaultDownloadConnectTimeout, "Maximum time in seconds that you allow the connection to the server to take.")
+	initCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -201,4 +201,5 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
+	initCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -98,9 +98,9 @@ Restart=on-failure
 RestartSec=5s
 
 LimitNOFILE=65536
-Nice=-10
-IOSchedulingClass=best-effort
-IOSchedulingPriority=2
+{{- range .EtcdDiskPriorities }}
+{{ . }}
+{{- end }}
 MemoryLow=200M
 
 [Install]
@@ -158,3 +158,10 @@ fi
 "{{ .EtcdctlExecutable }}" "$@"
 `
 )
+
+// DefaultEtcdDiskPriorities defines the default etcd disk priority.
+var DefaultEtcdDiskPriorities = []string{
+	"Nice=-10",
+	"IOSchedulingClass=best-effort",
+	"IOSchedulingPriority=2",
+}


### PR DESCRIPTION
Fix the issue: https://github.com/kubernetes-sigs/etcdadm/issues/62

I follow the https://etcd.io/docs/v3.3.12/tuning/#disk document and add `--disk-priorities` to support etcd disk tuning configurations.