### PR TITLE
bugfix: FileMode should be octal expressed

### DIFF
--- a/binary/etcd.go
+++ b/binary/etcd.go
@@ -154,7 +154,7 @@ func InstallFromCache(version, installDir, cacheDir string) (bool, error) {
 		return true, fmt.Errorf("unable to extract etcd archive: %s", err)
 	}
 	// Create the install dir
-	os.MkdirAll(installDir, 755)
+	os.MkdirAll(installDir, 0755)
 	// Copy binaries
 	if err := Install(tmpDir, installDir); err != nil {
 		return false, fmt.Errorf("unable to copy binaries: %s", err)


### PR DESCRIPTION
Add prefix `0`,  or it will be translated to decimal.