### PR TITLE
Logging consolidation

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -53,7 +53,7 @@ func CreatePKIAssets(cfg *apis.EtcdAdmConfig) error {
 		}
 	}
 
-	log.Printf("[certificates] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
+	log.Printf("[certificates] Valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
 
 	return nil
 }
@@ -63,7 +63,7 @@ func CreatePKIAssets(cfg *apis.EtcdAdmConfig) error {
 // This is a separate CA, so that kubernetes client identities cannot connect to etcd directly or peer with the etcd cluster.
 // If the etcd CA certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 func CreateEtcdCACertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
-	log.Print("creating a self signed etcd CA certificate and key files")
+	log.Print("[certificates] Creating a self signed etcd CA certificate and key files")
 	etcdCACert, etcdCAKey, err := NewEtcdCACertAndKey()
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func CreateEtcdCACertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
 // If the etcd serving certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateEtcdServerCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
-	log.Println("creating a new server certificate and key files for etcd")
+	log.Println("[certificates] Creating a new server certificate and key files for etcd")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, constants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func CreateEtcdServerCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
 // If the etcd peer certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateEtcdPeerCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
-	log.Println("creating a new certificate and key files for etcd peering")
+	log.Println("[certificates] Creating a new certificate and key files for etcd peering")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, constants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func CreateEtcdPeerCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
 // If the etcdctl-client certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateEtcdctlClientCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
-	log.Println("creating a new client certificate for the etcdctl")
+	log.Println("[certificates] Creating a new client certificate for the etcdctl")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, constants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func CreateEtcdctlClientCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
 // If the apiserver-etcd-client certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateAPIServerEtcdClientCertAndKeyFiles(cfg *apis.EtcdAdmConfig) error {
-	log.Println("creating a new client certificate for the apiserver calling etcd")
+	log.Println("[certificates] Creating a new client certificate for the apiserver calling etcd")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, constants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -53,7 +53,7 @@ func CreatePKIAssets(cfg *apis.EtcdAdmConfig) error {
 		}
 	}
 
-	fmt.Printf("[certificates] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
+	log.Printf("[certificates] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
 
 	return nil
 }
@@ -289,7 +289,7 @@ func writeCertificateAuthorithyFilesIfNotExist(pkiDir string, baseName string, c
 		// kubeadm doesn't validate the existing certificate Authority more than this;
 		// Basically, if we find a certificate file with the same path; and it is a CA
 		// kubeadm thinks those files are equal and doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
+		log.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
 	} else {
 
 		// Write .crt and .key files to disk
@@ -297,7 +297,7 @@ func writeCertificateAuthorithyFilesIfNotExist(pkiDir string, baseName string, c
 			return fmt.Errorf("failure while saving %s certificate and key: %v", baseName, err)
 		}
 
-		fmt.Printf("[certificates] Generated %s certificate and key.\n", baseName)
+		log.Printf("[certificates] Generated %s certificate and key.\n", baseName)
 	}
 	return nil
 }
@@ -325,7 +325,7 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 		// Basically, if we find a certificate file with the same path; and it is signed by
 		// the expected certificate authority, kubeadm thinks those files are equal and
 		// doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
+		log.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
 	} else {
 
 		// Write .crt and .key files to disk
@@ -333,9 +333,9 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 			return fmt.Errorf("failure while saving %s certificate and key: %v", baseName, err)
 		}
 
-		fmt.Printf("[certificates] Generated %s certificate and key.\n", baseName)
+		log.Printf("[certificates] Generated %s certificate and key.\n", baseName)
 		if pkiutil.HasServerAuth(cert) {
-			fmt.Printf("[certificates] %s serving cert is signed for DNS names %v and IPs %v\n", baseName, cert.DNSNames, cert.IPAddresses)
+			log.Printf("[certificates] %s serving cert is signed for DNS names %v and IPs %v\n", baseName, cert.DNSNames, cert.IPAddresses)
 		}
 	}
 
@@ -360,7 +360,7 @@ func writeKeyFilesIfNotExist(pkiDir string, baseName string, key *rsa.PrivateKey
 		// kubeadm doesn't validate the existing certificate key more than this;
 		// Basically, if we find a key file with the same path kubeadm thinks those files
 		// are equal and doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s key.\n", baseName)
+		log.Printf("[certificates] Using the existing %s key.\n", baseName)
 	} else {
 
 		// Write .key and .pub files to disk
@@ -371,7 +371,7 @@ func writeKeyFilesIfNotExist(pkiDir string, baseName string, key *rsa.PrivateKey
 		if err := pkiutil.WritePublicKey(pkiDir, baseName, &key.PublicKey); err != nil {
 			return fmt.Errorf("failure while saving %s public key: %v", baseName, err)
 		}
-		fmt.Printf("[certificates] Generated %s key and public key.\n", baseName)
+		log.Printf("[certificates] Generated %s key and public key.\n", baseName)
 	}
 
 	return nil

--- a/certs/pkiutil/pki_helpers.go
+++ b/certs/pkiutil/pki_helpers.go
@@ -34,6 +34,8 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"sigs.k8s.io/etcdadm/apis"
 	"sigs.k8s.io/etcdadm/constants"
+
+	log "sigs.k8s.io/etcdadm/pkg/logrus"
 )
 
 // NewCertificateAuthority creates new certificate and private key for the certificate authority
@@ -288,7 +290,7 @@ func appendSANsToAltNames(altNames *certutil.AltNames, SANs []string, certName s
 		} else if len(validation.IsDNS1123Subdomain(altname)) == 0 {
 			altNames.DNSNames = append(altNames.DNSNames, altname)
 		} else {
-			fmt.Printf(
+			log.Printf(
 				"[certificates] WARNING: '%s' was not added to the '%s' SAN, because it is not a valid IP or RFC-1123 compliant DNS entry\n",
 				altname,
 				certName,

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	log "sigs.k8s.io/etcdadm/pkg/logrus"
 
@@ -56,7 +55,7 @@ var infoCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("[info] Error parsing member information: %s", err)
 		}
-		fmt.Println(string(localMemberJSON))
+		log.Println(string(localMemberJSON))
 	},
 }
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	log "sigs.k8s.io/etcdadm/pkg/logrus"
 
@@ -55,7 +56,7 @@ var infoCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("[info] Error parsing member information: %s", err)
 		}
-		log.Println(string(localMemberJSON))
+		fmt.Println(string(localMemberJSON))
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -70,7 +71,7 @@ var initCmd = &cobra.Command{
 
 		exists, err := util.Exists(etcdAdmConfig.DataDir)
 		if err != nil {
-			log.Fatalf("Unable to verify whether data dir exists: %v", err)
+			log.Fatalf("[install] Unable to verify whether data dir exists: %v", err)
 		}
 		if exists {
 			log.Printf("[install] Removing existing data dir %q", etcdAdmConfig.DataDir)
@@ -146,8 +147,8 @@ var initCmd = &cobra.Command{
 
 		// Output etcdadm join command
 		// TODO print all advertised client URLs (first, join must parse than one endpoint)
-		log.Println("To add another member to the cluster, copy the CA cert/key to its certificate dir and run:")
-		log.Printf(`	etcdadm join %s`, etcdAdmConfig.AdvertiseClientURLs[0].String())
+		fmt.Println("To add another member to the cluster, copy the CA cert/key to its certificate dir and run:")
+		fmt.Printf(`	etcdadm join %s`, etcdAdmConfig.AdvertiseClientURLs[0].String())
 	},
 }
 

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -135,7 +135,7 @@ var joinCmd = &cobra.Command{
 			etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(desiredMembers)
 		} else {
 			log.Println("[membership] Member was started")
-			log.Printf("[membership] Keeping existing data dir %q", etcdAdmConfig.DataDir)
+			log.Printf("[membership] Keeping existing data dir %q\n", etcdAdmConfig.DataDir)
 			etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(members)
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -48,7 +47,7 @@ var (
 // Execute executes the root command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		os.Exit(1)
 	}
 }

--- a/hack/verify-boilerplate.go
+++ b/hack/verify-boilerplate.go
@@ -141,7 +141,7 @@ func verifyFile(filePath string) error {
 	}
 
 	if !isSupportedFileExtension(filePath) {
-		fmt.Printf("skipping %q: unsupported file type\n", filePath)
+		log.Printf("skipping %q: unsupported file type\n", filePath)
 		return nil
 	}
 
@@ -164,7 +164,7 @@ func main() {
 	hasErr := false
 	for _, filePath := range os.Args[1:] {
 		if err := verifyFile(filePath); err != nil {
-			fmt.Printf("error validating %q: %v\n", filePath, err)
+			log.Printf("error validating %q: %v\n", filePath, err)
 			hasErr = true
 		}
 	}


### PR DESCRIPTION
Initial PR to standardize most logs to use `logrus` in replacement for pure `fmt` (except for `Errorf()`). (#124)
Also, in certain cases, added the component/stage (e.g. [certificates]) as proposed


