### PR TITLE
Add a flag to support additional server SANs

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -157,6 +157,7 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	initCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.ServerCertSANs, "server-cert-extra-sans", etcdAdmConfig.ServerCertSANs, "optional extra Subject Alternative Names for the etcd server signing cert, can be multiple comma separated DNS names or IPs")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Snapshot, "snapshot", "", "Etcd v3 snapshot file used to initialize member")
 	initCmd.PersistentFlags().BoolVar(&etcdAdmConfig.SkipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -206,6 +206,7 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	joinCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.ServerCertSANs, "server-cert-extra-sans", etcdAdmConfig.ServerCertSANs, "optional extra Subject Alternative Names for the etcd server signing cert, can be multiple comma separated DNS names or IPs")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	joinCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 }


### PR DESCRIPTION
Fixes #75 

Verified certs generated by init and join have extra SANs:
```
etcdadm -l debug init --server-cert-extra-sans internal-etcd-2019121018425172030000000b-1499126190.us-west-2.elb.amazonaws.com --version 3.3.8
...
[certificates] Generated server certificate and key.
[certificates] server serving cert is signed for DNS names [internal-etcd-2019121018425172030000000b-1499126190.us-west-2.elb.amazonaws.com ip-10-0-1-23.us-west-2.compute.internal] and IPs [10.0.1.23 127.0.0.1]
```

```
etcdadm -l debug join --server-cert-extra-sans internal-etcd-2019121018425172030000000b-1499126190.us-west-2.elb.amazonaws.com --version 3.3.8 https://10.0.5.221:2379
...
[certificates] server serving cert is signed for DNS names [internal-etcd-2019121018425172030000000b-1499126190.us-west-2.elb.amazonaws.com ip-10-0-8-183.us-west-2.compute.internal] and IPs [127.0.0.1 10.0.8.183]
```