### PR TITLE
Ignore vendor directory when git push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 .DS_Store
 etcdadm
 plantuml.jar
+vendor


### PR DESCRIPTION
I update the lasted code, use `go mode vendor` that save the third party library to `vendor` directory, I found the `.gitignore` not ignore the `vendor` directory, so add this entry in `.gitignore` file.