### PR TITLE
Download etcd release abort and show error if package not found

### DIFF
--- a/binary/etcd.go
+++ b/binary/etcd.go
@@ -76,7 +76,7 @@ func isEtcdctlInstalled(version, inputDir string) (bool, error) {
 
 func get(url, archive string) error {
 	log.Printf("[install] downloading etcd from %s to %s\n", url, archive)
-	argStr := fmt.Sprintf("--connect-timeout %v --progress-bar --location --output %v %v", int(constants.DefaultDownloadConnectTimeout/time.Second), archive, url)
+	argStr := fmt.Sprintf("--fail --connect-timeout %v --progress-bar --location --output %v %v", int(constants.DefaultDownloadConnectTimeout/time.Second), archive, url)
 	cmd := exec.Command("curl", strings.Fields(argStr)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/etcdadm/issues/144

Add `--fail` when using `curl` download etcd release package. 

If etcd release package not found, `etcdadm` will show below logs:

```diff
[root@k8s-1 ~]# etcdadm init --name k8s --release-url http://192.168.10.108/tools/etcd --version 3.3.12 -l debug
INFO[0000] [install] Artifact not found in cache. Trying to fetch from upstream: http://192.168.10.108/tools/etcd
INFO[0000] [install] Downloading & installing etcd http://192.168.10.108/tools/etcd from 3.3.12 to /var/cache/etcdadm/etcd/v3.3.12
INFO[0000] [install] downloading etcd from http://192.168.10.108/tools/etcd/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz to /var/cache/etcdadm/etcd/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz

+curl: (22) The requested URL returned error: 404 Not Found
FATA[0000] [install] Unable to fetch artifact from upstream: unable to download etcd: exit status 22
```