### PR TITLE
Add backoff retry when join member at the same time

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -85,6 +85,10 @@ type EtcdAdmConfig struct {
 
 	Snapshot      string
 	SkipHashCheck bool
+
+	// Retry sets enable or disable backoff retry when join etcd member to cluster.
+	// Default true, it mean that enable backoff retry.
+	Retry bool
 }
 
 // EndpointStatus TODO: add description

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -157,6 +157,10 @@ fi
 . "{{ .EtcdctlEnvFile }}"
 "{{ .EtcdctlExecutable }}" "$@"
 `
+
+	DefaultBackOffSteps    = 5
+	DefaultBackOffDuration = 2 * time.Second
+	DefaultBackOffFactor   = 2.0
 )
 
 // DefaultEtcdDiskPriorities defines the default etcd disk priority.


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/etcdadm/issues/133

Add exponential backoff retry for join etcd member at the same time, e.g. 0, 1, 2, 4, 8s. The max retry is five times.