### PR TITLE
Add renew certificates subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ On the machine being removed, run
 etcdadm reset
 ```
 
+### Renewal certificates
+
+1. Ensure the CA certificate and key already exists on the machine.
+
+If not exists, Copy the CA certificate and key from other machine in the cluster.
+
+```
+rsync -avR /etc/etcd/pki/ca.* <Member IP address>:/
+```
+
+2. run command to renew certficates via CA certificate and key.
+
+```
+etcdadm certs renew
+```
+
 ## Advanced Usage
 
 ### Creating a new cluster from a snapshot

--- a/certs/pkiutil/pki_helpers.go
+++ b/certs/pkiutil/pki_helpers.go
@@ -185,6 +185,19 @@ func TryLoadCertAndKeyFromDisk(pkiPath, name string) (*x509.Certificate, *rsa.Pr
 	return cert, key, nil
 }
 
+// TryLoadCertFromDiskIgnoreExpirationDate tries to load the cert from the disk and ignore expiration date
+func TryLoadCertFromDiskIgnoreExpirationDate(pkiPath, name string) (*x509.Certificate, error) {
+	certificatePath := pathForCert(pkiPath, name)
+
+	certs, err := certutil.CertsFromFile(certificatePath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load the certificate file %s: %v", certificatePath, err)
+	}
+
+	// We are only putting one certificate in the certificate pem file, so it's safe to just pick the first one
+	return certs[0], nil
+}
+
 // TryLoadCertFromDisk tries to load the cert from the disk and validates that it is valid
 func TryLoadCertFromDisk(pkiPath, name string) (*x509.Certificate, error) {
 	certificatePath := pathForCert(pkiPath, name)

--- a/certs/pkiutil/pki_helpers_test.go
+++ b/certs/pkiutil/pki_helpers_test.go
@@ -307,6 +307,56 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 	}
 }
 
+func TestTryLoadCertFromDiskIgnoreExpirationDate(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	caCert, _, err := NewCertificateAuthority()
+	if err != nil {
+		t.Errorf(
+			"failed to create cert and key with an error: %v",
+			err,
+		)
+	}
+	err = WriteCert(tmpdir, "foo", caCert)
+	if err != nil {
+		t.Errorf(
+			"failed to write cert and key with an error: %v",
+			err,
+		)
+	}
+
+	var tests = []struct {
+		path     string
+		name     string
+		expected bool
+	}{
+		{
+			path:     "",
+			name:     "",
+			expected: false,
+		},
+		{
+			path:     tmpdir,
+			name:     "foo",
+			expected: true,
+		},
+	}
+	for _, rt := range tests {
+		_, actual := TryLoadCertFromDiskIgnoreExpirationDate(rt.path, rt.name)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed TryLoadCertFromDiskIgnoreExpirationDate:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}
+
 func TestTryLoadCertFromDisk(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/etcdadm/certs"
+	"sigs.k8s.io/etcdadm/constants"
+	log "sigs.k8s.io/etcdadm/pkg/logrus"
+)
+
+// newCmdCerts returns main command for certs phase
+func newCmdCerts() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "certs",
+		Short: "Commands related to handling etcdadm certificates",
+	}
+
+	cmd.AddCommand(newCmdCertsRenewal())
+
+	return cmd
+}
+
+func newCmdCertsRenewal() *cobra.Command {
+	var certificatesDir string
+	cmd := &cobra.Command{
+		Use:   "renew",
+		Short: "Renew certificates for a etcd cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, name := range certs.GetDefaultCertList() {
+				log.Printf("[renew] Renew etcd %s certificate.", name)
+				renewed, err := certs.RenewUsingLocalCA(certificatesDir, name)
+				if err != nil {
+					log.Fatalf("[renew] Error renew certificate %s: %v", name, err)
+				}
+				if !renewed {
+					log.Fatalf("Certificates %s can't be renewed.\n", name)
+				}
+			}
+			log.Println("The etcd certificates have been renewed successfully!")
+			log.Warnln("If kube-apiserver which version less than v1.10.0 is running, restart it so that it uses the renewed etcd client certificate.")
+		},
+	}
+	cmd.PersistentFlags().StringVar(&certificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newCmdCerts())
+}

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -37,13 +37,14 @@ func newCmdCerts() *cobra.Command {
 
 func newCmdCertsRenewal() *cobra.Command {
 	var certificatesDir string
+	var csrOnly bool
 	cmd := &cobra.Command{
 		Use:   "renew",
 		Short: "Renew certificates for a etcd cluster",
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range certs.GetDefaultCertList() {
 				log.Printf("[renew] Renew etcd %s certificate.", name)
-				renewed, err := certs.RenewUsingLocalCA(certificatesDir, name)
+				renewed, err := certs.RenewUsingLocalCA(certificatesDir, name, csrOnly)
 				if err != nil {
 					log.Fatalf("[renew] Error renew certificate %s: %v", name, err)
 				}
@@ -56,6 +57,7 @@ func newCmdCertsRenewal() *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&certificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	cmd.PersistentFlags().BoolVar(&csrOnly, "csr-only", false, "create CSRs instead of generating certificates")
 
 	return cmd
 }


### PR DESCRIPTION
The `etcdadm certs renew` support renew certificates with local CA, it will renew the etcd certificates exclude CA.

Now the `etcdadm` create etcd certificates default expiration time is one year. The cluster not work if time is more than one year. I use `kubeadm` create Kubernetes cluster and it also have the same question, however `kubeadm` have renew command to help us make certificates rotation, so i think it is better if `etcdadm`  have this renew command.'

I also found other people have this question, Ref: https://github.com/kubernetes-sigs/etcdadm/issues/56, so i send a PR to add a `renew` subcommand for implement it.

I'm not sure if missing something, if i missing, please tell me.