### PR TITLE
Build with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GIT_STORAGE_MOUNT := $(shell source ./git_utils.sh; container_git_storage_mount)
 default: $(BIN)
 
 container-build:
-	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE} -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) golang:1.11 /bin/bash -c "make ensure && make"
+	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE} -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) golang:1.12 /bin/bash -c "make ensure && make"
 
 $(BIN):
 	GO111MODULE=on go build -ldflags "$(LDFLAGS)"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ etcdadm is a command-line tool for operating an etcd cluster. It makes it easy t
 
 ### Building
 
-```
-go get -u sigs.k8s.io/etcdadm
-```
+1. Clone the git repository.
+1. Build on the host:
+   ```
+   make etcdadm
+   ```
+1. Build in a container, using docker:
+   ```
+   make container-build
+   ```
 
 ### Creating a new cluster
 


### PR DESCRIPTION
There's an issue with `go get` (https://github.com/kubernetes-sigs/etcdadm/issues/156). For now, let's recommend building with `make`.