### PR TITLE
added support for --listen-metrics-url parameter

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -68,7 +68,8 @@ type EtcdAdmConfig struct {
 	AdvertiseClientURLs      URLList
 	ListenClientURLs         URLList
 
-	LoopbackClientURL url.URL
+	LoopbackClientURL    url.URL
+	AdditionalMetricsURL url.URL
 
 	// ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
 	ServerCertSANs []string
@@ -200,6 +201,9 @@ func setDynamicDefaults(cfg *EtcdAdmConfig) error {
 	if err := DefaultClientURLs(cfg); err != nil {
 		return err
 	}
+	if cfg.AdditionalMetricsURL.String() == "" {
+		DefaultAdditionalMetricsURL(cfg)
+	}
 	DefaultPeerCertSANs(cfg)
 	DefaultServerCertSANs(cfg)
 	return nil
@@ -297,6 +301,19 @@ func DefaultAdvertiseClientURLs(cfg *EtcdAdmConfig) error {
 		Scheme: "https",
 		Host:   fmt.Sprintf("%s:%d", externalAddress.String(), constants.DefaultClientPort),
 	})
+	return nil
+}
+
+// DefaultAdditionalMetricsURL sets additional metrics url using node ip
+func DefaultAdditionalMetricsURL(cfg *EtcdAdmConfig) error {
+	externalAddress, err := defaultExternalAddress()
+	if err != nil {
+		return fmt.Errorf("failed to set default DefaultAdditionalMetricsURL: %s", err)
+	}
+	cfg.AdditionalMetricsURL = url.URL{
+		Scheme: constants.DefaultAdditionalMetricsScheme,
+		Host:   fmt.Sprintf("%s:%d", externalAddress.String(), constants.DefaultAdditionalMetricsPort),
+	}
 	return nil
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -163,4 +163,5 @@ func init() {
 	initCmd.PersistentFlags().BoolVar(&etcdAdmConfig.SkipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 	initCmd.PersistentFlags().DurationVar(&etcdAdmConfig.DownloadConnectTimeout, "download-connect-timeout", constants.DefaultDownloadConnectTimeout, "Maximum time in seconds that you allow the connection to the server to take.")
 	initCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
+	initCmd.PersistentFlags().Var(util.URLValue{URL: &etcdAdmConfig.AdditionalMetricsURL}, "listen-metrics-url", "URL to expose additional /metrics endpoint without TLS")
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/etcdadm/etcd"
 	"sigs.k8s.io/etcdadm/initsystem"
 	"sigs.k8s.io/etcdadm/service"
+	"sigs.k8s.io/etcdadm/util"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -235,4 +236,5 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	joinCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 	joinCmd.PersistentFlags().BoolVar(&etcdAdmConfig.Retry, "retry", true, "Enable or disable backoff retry when join etcd member to cluster")
+	joinCmd.PersistentFlags().Var(util.URLValue{URL: &etcdAdmConfig.AdditionalMetricsURL}, "listen-metrics-url", "URL to expose additional /metrics endpoint without TLS")
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -38,6 +38,9 @@ const (
 	DefaultPeerPort     = 2380
 	DefaultClientPort   = 2379
 
+	DefaultAdditionalMetricsPort   = 9379
+	DefaultAdditionalMetricsScheme = "http"
+
 	DefaultDownloadConnectTimeout = 10 * time.Second
 	DefaultEtcdRequestTimeout     = 5 * time.Second
 
@@ -126,6 +129,9 @@ ETCD_PEER_TRUSTED_CA_FILE={{ .PeerTrustedCAFile }}
 # Client/server configuration
 ETCD_ADVERTISE_CLIENT_URLS={{ .AdvertiseClientURLs.String }}
 ETCD_LISTEN_CLIENT_URLS={{ .ListenClientURLs.String }}
+{{- if .AdditionalMetricsURL.String }}
+ETCD_LISTEN_METRICS_URLS={{ .AdditionalMetricsURL.String }}
+{{- end }}
 
 ETCD_PEER_CLIENT_CERT_AUTH=true
 ETCD_CERT_FILE={{ .CertFile }}

--- a/util/url_value.go
+++ b/util/url_value.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/url"
+)
+
+// URLValue struct definition
+type URLValue struct {
+	URL *url.URL
+}
+
+// String reassembles the URL into a valid URL string
+func (s URLValue) String() string {
+	if s.URL != nil {
+		return s.URL.String()
+	}
+	return ""
+}
+
+// Set sets the argument passed to URL Value
+func (s URLValue) Set(val string) error {
+	if u, err := url.Parse(val); err != nil {
+		return err
+	} else {
+		*s.URL = *u
+	}
+	return nil
+}
+
+// Type returns type of struct
+func (s URLValue) Type() string {
+	return "URLValue"
+}

--- a/util/url_value.go
+++ b/util/url_value.go
@@ -35,11 +35,14 @@ func (s URLValue) String() string {
 
 // Set sets the argument passed to URL Value
 func (s URLValue) Set(val string) error {
-	if u, err := url.Parse(val); err != nil {
+
+	var u *url.URL
+	var err error
+
+	if u, err = url.ParseRequestURI(val); err != nil {
 		return err
-	} else {
-		*s.URL = *u
 	}
+	*s.URL = *u
 	return nil
 }
 


### PR DESCRIPTION
support for https://github.com/kubernetes-sigs/etcdadm/issues/157

@dlipovetsky 
Added new flag --listen-metrics-url

- If user passes a URL to this parameter, we'll use that URL to expose additional metrics endpoint in http
- By default (without passing any extra params) this will expose /metrics endpoint on http://client-ip:9379

I can't seem to make this optional without messing up with existing code structure. Let me know if I need to make any changes