### PR TITLE
Pare down InitSystem interface

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,24 +48,8 @@ var initCmd = &cobra.Command{
 			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
 		}
 
-		active, err := initSystem.IsActive(constants.UnitFileBaseName)
-		if err != nil {
-			log.Fatalf("[start] Error checking if etcd service is active: %s", err)
-		}
-		if active {
-			if err := initSystem.Stop(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[start] Error stopping existing etcd service: %s", err)
-			}
-		}
-
-		enabled, err := initSystem.IsEnabled(constants.UnitFileBaseName)
-		if err != nil {
-			log.Fatalf("[install] Error checking if etcd service is enabled: %s", err)
-		}
-		if enabled {
-			if err := initSystem.Disable(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[install] Error disabling existing etcd service: %s", err)
-			}
+		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
 		}
 
 		exists, err := util.Exists(etcdAdmConfig.DataDir)

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -58,24 +58,8 @@ var joinCmd = &cobra.Command{
 			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
 		}
 
-		active, err := initSystem.IsActive(constants.UnitFileBaseName)
-		if err != nil {
-			log.Fatalf("[start] Error checking if etcd service is active: %s", err)
-		}
-		if active {
-			if err := initSystem.Stop(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[start] Error stopping existing etcd service: %s", err)
-			}
-		}
-
-		enabled, err := initSystem.IsEnabled(constants.UnitFileBaseName)
-		if err != nil {
-			log.Fatalf("[start] Error checking if etcd service is enabled: %s", err)
-		}
-		if enabled {
-			if err := initSystem.Disable(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[start] Error disabling existing etcd service: %s", err)
-			}
+		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
 		}
 
 		// cert management

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -90,20 +90,11 @@ var resetCmd = &cobra.Command{
 					log.Println("[membership] Member was removed")
 				}
 			}
-			// Disable etcd service
-			if err := initSystem.Stop(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[reset] Error stopping existing etcd service: %s", err)
-			}
 		}
-		enabled, err := initSystem.IsEnabled(constants.UnitFileBaseName)
-		if err != nil {
-			log.Fatalf("[reset] Error checking if etcd service is enabled: %s", err)
+		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+			log.Fatalf("[reset] Error stopping etcd: %s", err)
 		}
-		if enabled {
-			if err := initSystem.Disable(constants.UnitFileBaseName); err != nil {
-				log.Fatalf("[reset] Error disabling existing etcd service: %s", err)
-			}
-		}
+
 		// Remove etcd datastore
 		if err = os.RemoveAll(etcdAdmConfig.DataDir); err != nil {
 			log.Print(err)

--- a/initsystem/initsystem.go
+++ b/initsystem/initsystem.go
@@ -23,12 +23,7 @@ import (
 
 // InitSystem is the interface that describe behaviors of an init system
 type InitSystem interface {
-	Start(service string) error
-	Stop(service string) error
-	Enable(service string) error
-	Disable(service string) error
 	IsActive(service string) (bool, error)
-	IsEnabled(service string) (bool, error)
 	EnableAndStartService(service string) error
 	DisableAndStopService(service string) error
 }


### PR DESCRIPTION
By reducing the surface, we make it easier to implement other
backends (mock & kubelet)