### PR TITLE
Set default etcd version to 3.4.9, the default for Kubernetes 1.19

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -20,7 +20,7 @@ import "time"
 
 // Command-line flag defaults
 const (
-	DefaultVersion    = "3.3.8"
+	DefaultVersion    = "3.4.9"
 	DefaultInstallDir = "/opt/bin/"
 
 	DefaultReleaseURL     = "https://github.com/coreos/etcd/releases/download"


### PR DESCRIPTION
I propose setting the default etcd version to whatever is used in the latest Kubernetes release.

Once this merges, I plan to create a new etcdadm release.