### PR TITLE
Initial cloudbuild staging job

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,4 @@
+# Do not ignore .git directory in CloudBuild; needed to determine version                                
+#.git                                                                                                    
+
+#!include:.gitignore

--- a/dev/staging/README.md
+++ b/dev/staging/README.md
@@ -1,0 +1,17 @@
+This cloudbuild job is invoked by prow after every commit to master,
+and will push images to the staging image repository.
+
+It can also be run against your own GCP project, which is helpful when
+testing or adding to the cloudbuild job.  An example command is:
+
+```
+# Choose a bucket to upload to
+ARTIFACT_LOCATION=gs://$(gcloud config get-value project)-staging/etcdadm
+
+gcloud builds submit --config=dev/staging/cloudbuild.yaml . \
+    --substitutions=_DOCKER_IMAGE_PREFIX=$(gcloud config get-value project)/ \
+    --substitutions=_ARTIFACT_LOCATION=${ARTIFACT_LOCATION}
+
+gsutil ls -r ${ARTIFACT_LOCATION}/
+```
+

--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
+steps:
+- name: gcr.io/k8s-testimages/krte:latest-master
+  env:
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - VERSION=$_GIT_TAG
+  - DOCKER_REGISTRY=$_DOCKER_REGISTRY
+  - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
+  - ARTIFACT_LOCATION=$_ARTIFACT_LOCATION
+  entrypoint: dev/staging/push.sh
+substitutions:
+  _GIT_TAG: 'dev'
+  _PULL_BASE_REF: 'dev'
+  _DOCKER_REGISTRY: 'gcr.io'
+  _DOCKER_IMAGE_PREFIX: 'k8s-staging-etcdadm/'
+  _ARTIFACT_LOCATION: 'gs://k8s-staging-etcdadm/ci/builds/'

--- a/dev/staging/push.sh
+++ b/dev/staging/push.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+set -x;
+
+# cd to the repo root
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if [[ -z "${VERSION:-}" ]]; then
+  VERSION=$(git describe --always)
+fi
+
+if [[ -z "${DOCKER_REGISTRY:-}" ]]; then
+  DOCKER_REGISTRY=gcr.io
+fi
+
+if [[ -z "${DOCKER_IMAGE_PREFIX:-}" ]]; then
+  DOCKER_IMAGE_PREFIX=k8s-staging-etcdadm/
+fi
+
+if [[ -z "${ARTIFACT_LOCATION:-}" ]]; then
+  echo "must set ARTIFACT_LOCATION for binary artifacts"
+  exit 1
+fi
+
+# Build and upload etcdadm binary
+make etcdadm
+gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n etcdadm ${ARTIFACT_LOCATION}/${VERSION}/etcdadm


### PR DESCRIPTION
Published the etcdadm binary to the staging bucket.

We'll want to include the etcd-manager build and build for multi-arch
in later steps.