### PR TITLE
update shellcheck url

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -35,7 +35,7 @@ trap cleanup EXIT
 cd "${TMP_DIR}" || exit
 VERSION="shellcheck-v0.6.0"
 DOWNLOAD_FILE="${VERSION}.linux.x86_64.tar.xz"
-wget https://storage.googleapis.com/shellcheck/"${DOWNLOAD_FILE}"
+wget https://github.com/koalaman/shellcheck/releases/download/${VERSION#shellcheck-}/"${DOWNLOAD_FILE}"
 tar xf "${DOWNLOAD_FILE}"
 cd "${VERSION}" || exit
 


### PR DESCRIPTION
the origin shellcheck output:

You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.6.0/shellcheck-v0.6.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>