### PR TITLE
etcd-manager/dev: move script interpreter to the first line

### DIFF
--- a/etcd-manager/dev/add-symlink.sh
+++ b/etcd-manager/dev/add-symlink.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash -e
 
 pushd pkg/privateapi/
 ln -sf ../../bazel-bin/pkg/privateapi/linux_amd64_stripped/privateapi_go_proto~/sigs.k8s.io/etcdadm/etcd-manager/pkg/privateapi/cluster.pb.go

--- a/etcd-manager/dev/build-assets.sh
+++ b/etcd-manager/dev/build-assets.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 VERSION=$1
 PLATFORMS="linux_amd64 darwin_amd64 windows_amd64"

--- a/etcd-manager/dev/check-hashes.sh
+++ b/etcd-manager/dev/check-hashes.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/etcd-manager/dev/release.sh
+++ b/etcd-manager/dev/release.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 TODAY=`date +%Y%m%d`
 VERSION="3.0.${TODAY}"


### PR DESCRIPTION
Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>