### PR TITLE
Fix go module path for etcd-manager/tools/deb-tools

### DIFF
--- a/etcd-manager/tools/deb-tools/go.mod
+++ b/etcd-manager/tools/deb-tools/go.mod
@@ -1,4 +1,4 @@
-module kope.io/etcd-manager/tools/deb-tools
+module sigs.k8s.io/etcdadm/etcd-manager/tools/deb-tools
 
 go 1.12
 

--- a/etcd-manager/tools/deb-tools/vendor/github.com/go-logr/logr/BUILD.bazel
+++ b/etcd-manager/tools/deb-tools/vendor/github.com/go-logr/logr/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["logr.go"],
-    importmap = "sigs.k8s.io/etcdadm/etcd-manager/tools/deb-extract/vendor/github.com/go-logr/logr",
+    importmap = "kope.io/etcd-manager/tools/deb-extract/vendor/github.com/go-logr/logr",
     importpath = "github.com/go-logr/logr",
     visibility = ["//visibility:public"],
 )

--- a/etcd-manager/tools/deb-tools/vendor/k8s.io/klog/v2/BUILD.bazel
+++ b/etcd-manager/tools/deb-tools/vendor/k8s.io/klog/v2/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "klog.go",
         "klog_file.go",
     ],
-    importmap = "sigs.k8s.io/etcdadm/etcd-manager/tools/deb-extract/vendor/k8s.io/klog/v2",
+    importmap = "kope.io/etcd-manager/tools/deb-extract/vendor/k8s.io/klog/v2",
     importpath = "k8s.io/klog/v2",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/go-logr/logr:go_default_library"],


### PR DESCRIPTION
This was missed during the move, caught by `make vendor` in the etcd-manager directory