### PR TITLE
Install bazel in staging build

### DIFF
--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -10,6 +10,7 @@ steps:
   - DOCKER_REGISTRY=$_DOCKER_REGISTRY
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   - ARTIFACT_LOCATION=$_ARTIFACT_LOCATION
+  - INSTALL_BAZELISK=y
   entrypoint: dev/staging/push.sh
 substitutions:
   _GIT_TAG: 'dev'

--- a/dev/staging/push.sh
+++ b/dev/staging/push.sh
@@ -37,6 +37,15 @@ if [[ -z "${ARTIFACT_LOCATION:-}" ]]; then
   exit 1
 fi
 
+if [[ -n "${INSTALL_BAZELISK:-}" ]]; then
+  DOWNLOAD_URL="https://github.com/bazelbuild/bazelisk/releases/download/v1.7.2/bazelisk-linux-amd64"
+  echo "Downloading bazelisk from $DOWNLOAD_URL"
+  curl -L --output "/tmp/bazelisk" "${DOWNLOAD_URL}"
+  chmod +x "/tmp/bazelisk"
+  # Install to /usr/local/bin, as bazel
+  mv "/tmp/bazelisk" "/usr/local/bin/bazel"
+fi
+
 # Build and upload etcdadm binary
 make etcdadm
 gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n etcdadm ${ARTIFACT_LOCATION}/${VERSION}/etcdadm


### PR DESCRIPTION
A little inefficient, but means that we can control our bazel version
and not rely on the upstream image.