### PR TITLE
Add OWNERS file from kOps to etcd-manager

### DIFF
--- a/etcd-manager/OWNERS
+++ b/etcd-manager/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# These OWNERS files should stay in sync (if they are members of the kubernetes-sigs org):
+# https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kops/OWNERS
+# https://github.com/kubernetes/test-infra/blob/master/config/testgrids/kubernetes/kops/OWNERS
+
+approvers:
+- hakman
+- justinsb
+- olemarkus
+- rifelpet
+reviewers:
+- hakman
+- justinsb
+- olemarkus


### PR DESCRIPTION
As the main user for etcd-manager is kOps, makes sense to copy the OWNERS file from there to allow kOps maintainers to review PRs.
This has to be limited to those that are members of the kubernetes-sigs org.