### PR TITLE
OWNERS: Add etcd-manager owners to top-level owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,3 +10,6 @@ aliases:
   etcdadm-maintainers:
     - dlipovetsky
     - justinsb
+    - hakman
+    - olemarkus
+    - rifelpet


### PR DESCRIPTION
This should support better integration between etcdadm / etcd-manager.