### PR TITLE
Set default etcd version to 3.4.13, current for Kubernetes 1.19, 1.20, and 1.21

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -20,7 +20,7 @@ import "time"
 
 // Command-line flag defaults
 const (
-	DefaultVersion    = "3.4.9"
+	DefaultVersion    = "3.4.13"
 	DefaultInstallDir = "/opt/bin/"
 
 	DefaultReleaseURL     = "https://github.com/coreos/etcd/releases/download"


### PR DESCRIPTION
Fixes #218 