### PR TITLE
Add support for etcd 3.5.0

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -20,7 +20,7 @@ import "time"
 
 // Command-line flag defaults
 const (
-	DefaultVersion    = "3.4.13"
+	DefaultVersion    = "3.5.0"
 	DefaultInstallDir = "/opt/bin/"
 
 	DefaultReleaseURL     = "https://github.com/coreos/etcd/releases/download"

--- a/etcd-manager/WORKSPACE
+++ b/etcd-manager/WORKSPACE
@@ -216,6 +216,18 @@ go_repository(
     build_file_proto_mode = "disable_global",
 )
 
+http_file(
+    name = "etcd_3.5.0_amd64_tar",
+    sha256 = "864baa0437f8368e0713d44b83afe21dce1fb4ee7dae4ca0f9dd5f0df22d01c4",
+    urls = ["https://github.com/etcd-io/etcd/releases/download/v3.5.0/etcd-v3.5.0-linux-amd64.tar.gz"],
+)
+
+http_file(
+    name = "etcd_3.5.0_arm64_tar",
+    sha256 = "444e10e6880595d75aaf55762901c722049b29d56fef50b2f23464bb7f9db74d",
+    urls = ["https://github.com/etcd-io/etcd/releases/download/v3.5.0/etcd-v3.5.0-linux-arm64.tar.gz"],
+)
+
 #=============================================================================
 
 http_file(

--- a/etcd-manager/images/BUILD
+++ b/etcd-manager/images/BUILD
@@ -27,6 +27,7 @@ load("etcd.bzl", "supported_etcd_arch_and_version")
 # Layer for etcd 3.3.17, updated recommendation for k8s 1.16.3 and later
 # Layer for etcd 3.4.3, updated recommendation for k8s 1.17 and later
 # Layer for etcd 3.4.13, updated recommendation for k8s 1.19 and later
+# Layer for etcd 3.5.0, updated recommendation for k8s 1.22 and later
 [
     container_layer(
         name = "etcd-{version}-layer-{arch}".format(
@@ -71,6 +72,7 @@ container_image(
             "etcd-3.3.17-layer-amd64",
             "etcd-3.4.3-layer-amd64",
             "etcd-3.4.13-layer-amd64",
+            "etcd-3.5.0-layer-amd64",
         ],
         "@io_bazel_rules_go//go/platform:arm64": [
             "etcd-3.2.18-layer-arm64",
@@ -80,6 +82,7 @@ container_image(
             "etcd-3.3.17-layer-arm64",
             "etcd-3.4.3-layer-arm64",
             "etcd-3.4.13-layer-arm64",
+            "etcd-3.5.0-layer-arm64",
         ],
     }),
 )

--- a/etcd-manager/images/etcd.bzl
+++ b/etcd-manager/images/etcd.bzl
@@ -7,5 +7,5 @@ def supported_etcd_arch_and_version():
   ] + [
     (arch, version)
       for arch in ["amd64", "arm64"]
-      for version in ["3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3","3.4.13"]
+      for version in ["3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3","3.4.13","3.5.0"]
   ]

--- a/etcd-manager/pkg/etcdversions/mappings.go
+++ b/etcd-manager/pkg/etcdversions/mappings.go
@@ -36,6 +36,7 @@ const (
 	Version_3_3_17 = "3.3.17"
 	Version_3_4_3  = "3.4.3"
 	Version_3_4_13 = "3.4.13"
+	Version_3_5_0  = "3.5.0"
 )
 
 var AllEtcdVersions = []string{
@@ -48,6 +49,7 @@ var AllEtcdVersions = []string{
 	Version_3_3_17,
 	Version_3_4_3,
 	Version_3_4_13,
+	Version_3_5_0,
 }
 
 func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
@@ -131,6 +133,8 @@ func EtcdVersionForAdoption(fromVersion string) string {
 		} else {
 			return Version_3_4_13
 		}
+	case "3.5":
+		return Version_3_5_0
 	default:
 		return ""
 	}
@@ -171,6 +175,8 @@ func EtcdVersionForRestore(fromVersion string) string {
 		} else {
 			return Version_3_4_13
 		}
+	case "3.5":
+		return Version_3_5_0
 	default:
 		return ""
 	}

--- a/etcd-manager/test/integration/BUILD.bazel
+++ b/etcd-manager/test/integration/BUILD.bazel
@@ -28,6 +28,8 @@ go_test(
         "//:etcd-v3.4.13-linux-amd64_etcdctl",
         "//:etcd-v3.4.3-linux-amd64_etcd",
         "//:etcd-v3.4.3-linux-amd64_etcdctl",
+        "//:etcd-v3.5.0-linux-amd64_etcd",
+        "//:etcd-v3.5.0-linux-amd64_etcdctl",
         "@etcd_v2_2_1_source//:etcd",
         "@etcd_v2_2_1_source//etcdctl",
     ],

--- a/etcd-manager/test/integration/clusterformation_test.go
+++ b/etcd-manager/test/integration/clusterformation_test.go
@@ -77,7 +77,7 @@ func TestClusterWithThreeMembers(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -107,7 +107,7 @@ func TestClusterExpansion(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -159,7 +159,7 @@ func TestWeOnlyFormASingleCluster(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")

--- a/etcd-manager/test/integration/datapersists_test.go
+++ b/etcd-manager/test/integration/datapersists_test.go
@@ -34,7 +34,7 @@ func TestClusterDataPersists(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -92,7 +92,7 @@ func TestHAReadWrite(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")
@@ -160,7 +160,7 @@ func TestHARecovery(t *testing.T) {
 	defer cancel()
 
 	h := harness.NewTestHarness(t, ctx)
-	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.4.13"})
+	h.SeedNewCluster(&protoetcd.ClusterSpec{MemberCount: 3, EtcdVersion: "3.5.0"})
 	defer h.Close()
 
 	n1 := h.NewNode("127.0.0.1")

--- a/etcd-manager/test/integration/harness/cluster.go
+++ b/etcd-manager/test/integration/harness/cluster.go
@@ -156,7 +156,7 @@ func (h *TestHarness) NewNode(address string) *TestHarnessNode {
 		TestHarness: h,
 		Address:     address,
 		NodeDir:     nodeDir,
-		EtcdVersion: "3.4.13",
+		EtcdVersion: "3.5.0",
 	}
 	if err := n.Init(); err != nil {
 		t.Fatalf("error initializing node: %v", err)


### PR DESCRIPTION
k/k is planning to upgrade etcd to v3.5.0 for the v1.22 Kubernetes release.
xRef: https://github.com/kubernetes/kubernetes/issues/102294