### PR TITLE
add custom bind addresss support to init

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -303,7 +303,7 @@ func DefaultAdvertiseClientURLs(cfg *EtcdAdmConfig) error {
 	return nil
 }
 
-// Returns the address associated with the host's default interface.
+// Returns the user-defined address; if that is undefined, returns the address associated with the host's default interface.
 func defaultExternalAddress(addr string) (net.IP, error) {
 	var (
 		ip  net.IP

--- a/apis/config.go
+++ b/apis/config.go
@@ -55,6 +55,8 @@ type EtcdAdmConfig struct {
 	InstallDir string
 	CacheDir   string
 
+	BindAddr string
+
 	UnitFile            string
 	EnvironmentFile     string
 	EtcdExecutable      string
@@ -255,7 +257,8 @@ func DefaultClientURLs(cfg *EtcdAdmConfig) error {
 
 // DefaultInitialAdvertisePeerURLs TODO: add description
 func DefaultInitialAdvertisePeerURLs(cfg *EtcdAdmConfig) error {
-	externalAddress, err := defaultExternalAddress()
+	externalAddress, err := defaultExternalAddress(cfg.BindAddr)
+
 	if err != nil {
 		return fmt.Errorf("failed to set default InitialAdvertisePeerURLs: %s", err)
 	}
@@ -289,7 +292,7 @@ func DefaultListenClientURLs(cfg *EtcdAdmConfig) error {
 
 // DefaultAdvertiseClientURLs TODO: add description
 func DefaultAdvertiseClientURLs(cfg *EtcdAdmConfig) error {
-	externalAddress, err := defaultExternalAddress()
+	externalAddress, err := defaultExternalAddress(cfg.BindAddr)
 	if err != nil {
 		return fmt.Errorf("failed to set default AdvertiseClientURLs: %s", err)
 	}
@@ -301,10 +304,37 @@ func DefaultAdvertiseClientURLs(cfg *EtcdAdmConfig) error {
 }
 
 // Returns the address associated with the host's default interface.
-func defaultExternalAddress() (net.IP, error) {
-	ip, err := netutil.ResolveBindAddress(net.ParseIP("0.0.0.0"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find a default external address: %s", err)
+func defaultExternalAddress(addr string) (net.IP, error) {
+	var (
+		ip  net.IP
+		err error
+	)
+
+	if addr == "" || addr == "0.0.0.0" {
+		ip, err := netutil.ResolveBindAddress(net.ParseIP("0.0.0.0"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to find a default external address: %s", err)
+		}
+		return ip, nil
 	}
-	return ip, nil
+
+	ip = net.ParseIP(addr)
+	if ip == nil {
+		return nil, fmt.Errorf(`invalid bind address "%s": invalid ip format`, addr)
+	}
+
+	systemAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list system unicast addresses to validate bind address: %w", err)
+	}
+
+	for _, sa := range systemAddrs {
+		if ipNet, ok := sa.(*net.IPNet); ok {
+			if ipNet.IP.Equal(ip) {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("invalid bind address %s: not found in system interfaces", addr)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -141,6 +141,7 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.BindAddr, "bind-address", "", "etcd bind address")
 	initCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.ServerCertSANs, "server-cert-extra-sans", etcdAdmConfig.ServerCertSANs, "optional extra Subject Alternative Names for the etcd server signing cert, can be multiple comma separated DNS names or IPs")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Snapshot, "snapshot", "", "Etcd v3 snapshot file used to initialize member")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -215,6 +215,7 @@ func init() {
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ReleaseURL, "release-url", constants.DefaultReleaseURL, "URL used to download etcd")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.CertificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.BindAddr, "bind-address", "", "etcd bind address")
 	joinCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.ServerCertSANs, "server-cert-extra-sans", etcdAdmConfig.ServerCertSANs, "optional extra Subject Alternative Names for the etcd server signing cert, can be multiple comma separated DNS names or IPs")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.InstallDir, "install-dir", constants.DefaultInstallDir, "install directory")
 	joinCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")


### PR DESCRIPTION
this pull request adds `--bind-address` to specify listen address generated in `etcd.env`