### PR TITLE
Init and join command phases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,31 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build etcdadm
+      run: make container-build
+    - uses: actions/cache@v2
+      with:
+        path: ./etcdadm
+        key: ${{ runner.os }}-etcdadm-bin-${{ github.sha }}
+
+  cluster-create-phases-test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/cache@v2
+      with:
+        path: ./etcdadm
+        key: ${{ runner.os }}-etcdadm-bin-${{ github.sha }}
+    - name: Run create cluster with etcdadm phases e2e test
+      run: ./test/e2e/cluster_phases.sh

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@
 #
 # Usage:
 # make                 # builds the artifact
-# make ensure          # runs dep ensure
-# make container-build # build artifact on a Linux based container using golang:1.12
+# make container-build # build artifact on a Linux based container using golang:1.16
 
 SHELL := /usr/bin/env bash
 CWD := $(shell pwd)
@@ -30,7 +29,7 @@ GO_IMAGE ?= golang:1.16
 default: $(BIN)
 
 container-build:
-	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE} -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make ensure && make"
+	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE} -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make"
 
 $(BIN):
 	GO111MODULE=on go build -ldflags "$(LDFLAGS)"

--- a/apis/config.go
+++ b/apis/config.go
@@ -108,6 +108,7 @@ type EtcdAdmConfig struct {
 	// EnableV2 configures whether the V2 client handler is configured, mapping to the --enable-v2 flag
 	// This is a bool, but we use a string because the default value changes across versions.
 	EnableV2 string
+	Endpoint string
 }
 
 // InitSystem represents the different types of init system

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -33,82 +34,9 @@ import (
 	"sigs.k8s.io/etcdadm/util"
 )
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a new etcd cluster",
-	Run: func(cmd *cobra.Command, args []string) {
-		apis.SetDefaults(&etcdAdmConfig)
-		if err := apis.SetInitDynamicDefaults(&etcdAdmConfig); err != nil {
-			log.Fatalf("[defaults] Error: %s", err)
-		}
-
-		initSystem, err := initsystem.GetInitSystem(&etcdAdmConfig)
-		if err != nil {
-			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
-		}
-
-		if err := initSystem.DisableAndStopService(); err != nil {
-			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
-		}
-
-		exists, err := util.Exists(etcdAdmConfig.DataDir)
-		if err != nil {
-			log.Fatalf("Unable to verify whether data dir exists: %v", err)
-		}
-		if exists {
-			log.Printf("[install] Removing existing data dir %q", etcdAdmConfig.DataDir)
-			os.RemoveAll(etcdAdmConfig.DataDir)
-		}
-
-		if err = initSystem.Install(); err != nil {
-			log.Fatalf("[install] Error: %s", err)
-		}
-		// cert management
-		if err = certs.CreatePKIAssets(&etcdAdmConfig); err != nil {
-			log.Fatalf("[certificates] Error: %s", err)
-		}
-		if etcdAdmConfig.Snapshot != "" {
-			if err := etcd.RestoreSnapshot(&etcdAdmConfig); err != nil {
-				log.Fatalf("[snapshot] Error restoring snapshot: %v", err)
-			}
-		}
-		if err = initSystem.Configure(); err != nil {
-			log.Fatalf("[configure] Error: %s", err)
-		}
-		if err = initSystem.EnableAndStartService(); err != nil {
-			log.Fatalf("[start] Error: %s", err)
-		}
-		if err = service.WriteEtcdctlEnvFile(&etcdAdmConfig); err != nil {
-			log.Printf("[configure] Warning: %s", err)
-		}
-		if err = service.WriteEtcdctlShellWrapper(&etcdAdmConfig); err != nil {
-			log.Printf("[configure] Warning: %s", err)
-		}
-
-		log.Println("[health] Checking local etcd endpoint health")
-		client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
-		if err != nil {
-			log.Printf("[health] Error checking health: %v", err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), initSystem.StartupTimeout())
-		_, err = client.Get(ctx, constants.EtcdHealthCheckKey)
-		cancel()
-		// Healthy because the cluster reaches consensus for the get request,
-		// even if permission (to get the key) is denied.
-		if err == nil || err == rpctypes.ErrPermissionDenied {
-			log.Println("[health] Local etcd endpoint is healthy")
-		} else {
-			log.Fatalf("[health] Local etcd endpoint is unhealthy: %v", err)
-		}
-
-		// Output etcdadm join command
-		// TODO print all advertised client URLs (first, join must parse than one endpoint)
-		log.Println("To add another member to the cluster, copy the CA cert/key to its certificate dir and run:")
-		log.Printf(`	etcdadm join %s`, etcdAdmConfig.AdvertiseClientURLs[0].String())
-	},
-}
-
 func init() {
+	runner := newInitRunner()
+	initCmd := newInitCmd(runner)
 	rootCmd.AddCommand(initCmd)
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Name, "name", "", "etcd member name")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
@@ -123,4 +51,176 @@ func init() {
 	initCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 	initCmd.PersistentFlags().StringVar((*string)(&etcdAdmConfig.InitSystem), "init-system", string(apis.Systemd), "init system type (systemd or kubelet)")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+
+	runner.registerPhasesAsSubcommands(initCmd)
+}
+
+func newInitCmd(runner *runner) *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a new etcd cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runner.run(); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+func newInitRunner() *runner {
+	runner := newRunner(setup)
+	runner.registerPhases(
+		install(),
+		certificates(),
+		snapshot(),
+		configure(),
+		start(),
+		etcdctl(),
+		healthcheck(),
+	)
+
+	return runner
+}
+
+func setup() (*phaseInput, error) {
+	apis.SetDefaults(&etcdAdmConfig)
+	if err := apis.SetInitDynamicDefaults(&etcdAdmConfig); err != nil {
+		return nil, fmt.Errorf("[defaults] error setting init dynamic defaults: %w", err)
+	}
+
+	initSystem, err := initsystem.GetInitSystem(&etcdAdmConfig)
+	if err != nil {
+		return nil, fmt.Errorf("[initsystem] error detecting the init system: %w", err)
+	}
+
+	in := &phaseInput{
+		initSystem:    initSystem,
+		etcdAdmConfig: &etcdAdmConfig,
+	}
+
+	return in, nil
+}
+
+func install() phase {
+	return &singlePhase{
+		phaseName: "install",
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.DisableAndStopService(); err != nil {
+				return fmt.Errorf("error disabling and stopping etcd service: %w", err)
+			}
+			exists, err := util.Exists(in.etcdAdmConfig.DataDir)
+			if err != nil {
+				return fmt.Errorf("unable to verify whether data dir exists: %w", err)
+			}
+			if exists {
+				log.Printf("[install] Removing existing data dir %q", in.etcdAdmConfig.DataDir)
+				os.RemoveAll(in.etcdAdmConfig.DataDir)
+			}
+			if err = in.initSystem.Install(); err != nil {
+				return fmt.Errorf("failed installing init system components: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func certificates() phase {
+	return &singlePhase{
+		phaseName: "certificates",
+		runFunc: func(in *phaseInput) error {
+			if err := certs.CreatePKIAssets(in.etcdAdmConfig); err != nil {
+				return fmt.Errorf("failed creating PKI assets: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func snapshot() phase {
+	return &singlePhase{
+		phaseName: "snapshot",
+		runFunc: func(in *phaseInput) error {
+			if in.etcdAdmConfig.Snapshot != "" {
+				if err := etcd.RestoreSnapshot(&etcdAdmConfig); err != nil {
+					return fmt.Errorf("error restoring snapshot: %w", err)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func configure() phase {
+	return &singlePhase{
+		phaseName: "configure",
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.Configure(); err != nil {
+				return fmt.Errorf("error configuring init system: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func start() phase {
+	return &singlePhase{
+		phaseName: "start",
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.EnableAndStartService(); err != nil {
+				return fmt.Errorf("error starting etcd: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func etcdctl() phase {
+	return &singlePhase{
+		phaseName: "etcdctl",
+		runFunc: func(in *phaseInput) error {
+			if err := service.WriteEtcdctlEnvFile(in.etcdAdmConfig); err != nil {
+				log.Printf("[etcdctl] Warning: %s", err)
+			}
+			if err := service.WriteEtcdctlShellWrapper(in.etcdAdmConfig); err != nil {
+				log.Printf("[etcdctl] Warning: %s", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func healthcheck() phase {
+	return &singlePhase{
+		phaseName: "health",
+		runFunc: func(in *phaseInput) error {
+			log.Println("[health] Checking local etcd endpoint health")
+			client, err := etcd.ClientForEndpoint(in.etcdAdmConfig.LoopbackClientURL.String(), in.etcdAdmConfig)
+			if err != nil {
+				return fmt.Errorf("error creating health endpoint client: %w", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), in.initSystem.StartupTimeout())
+			_, err = client.Get(ctx, constants.EtcdHealthCheckKey)
+			cancel()
+			// Healthy because the cluster reaches consensus for the get request,
+			// even if permission (to get the key) is denied.
+			if err == nil || err == rpctypes.ErrPermissionDenied {
+				log.Println("[health] Local etcd endpoint is healthy")
+			} else {
+				return fmt.Errorf("local etcd endpoint is unhealthy: %w", err)
+			}
+
+			// Output etcdadm join command
+			// TODO print all advertised client URLs (first, join must parse than one endpoint)
+			log.Println("To add another member to the cluster, copy the CA cert/key to its certificate dir and run:")
+			log.Printf(`	etcdadm join %s`, etcdAdmConfig.AdvertiseClientURLs[0].String())
+
+			return nil
+		},
+	}
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 
@@ -25,163 +26,18 @@ import (
 
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"sigs.k8s.io/etcdadm/apis"
-	"sigs.k8s.io/etcdadm/certs"
 	"sigs.k8s.io/etcdadm/constants"
 	"sigs.k8s.io/etcdadm/etcd"
 	"sigs.k8s.io/etcdadm/initsystem"
-	"sigs.k8s.io/etcdadm/service"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var joinCmd = &cobra.Command{
-	Use:   "join",
-	Short: "Join an existing etcd cluster",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		endpoint := args[0]
-		if _, err := url.Parse(endpoint); err != nil {
-			log.Fatalf("Error: endpoint %q must be a valid URL: %s", endpoint, err)
-		}
-
-		apis.SetDefaults(&etcdAdmConfig)
-		if err := apis.SetJoinDynamicDefaults(&etcdAdmConfig); err != nil {
-			log.Fatalf("[defaults] Error: %s", err)
-		}
-
-		initSystem, err := initsystem.GetInitSystem(&etcdAdmConfig)
-		if err != nil {
-			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
-		}
-
-		if err := initSystem.DisableAndStopService(); err != nil {
-			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
-		}
-
-		// cert management
-		if err := certs.CreatePKIAssets(&etcdAdmConfig); err != nil {
-			log.Fatalf("[certificates] Error: %s", err)
-		}
-
-		var localMember *etcdserverpb.Member
-		var members []*etcdserverpb.Member
-		log.Println("[membership] Checking if this member was added")
-		client, err := etcd.ClientForEndpoint(endpoint, &etcdAdmConfig)
-		if err != nil {
-			log.Fatalf("[membership] Error checking membership: %v", err)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
-		mresp, err := client.MemberList(ctx)
-		cancel()
-		if err != nil {
-			log.Fatalf("[membership] Error listing members: %v", err)
-		}
-		members = mresp.Members
-		localMember, ok := etcd.MemberForPeerURLs(members, etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
-		if !ok {
-			log.Printf("[membership] Member was not added")
-			log.Printf("Removing existing data dir %q", etcdAdmConfig.DataDir)
-			os.RemoveAll(etcdAdmConfig.DataDir)
-			log.Println("[membership] Adding member")
-
-			var lastErr error
-			retrySteps := 1
-			if etcdAdmConfig.Retry {
-				retrySteps = constants.DefaultBackOffSteps
-			}
-
-			// Exponential backoff for MemberAdd (values exclude jitter):
-			// If --retry=false, add member only try one times, otherwise try five times.
-			// The backoff duration is 0, 2, 4, 8, 16 s
-			opts := wait.Backoff{
-				Duration: constants.DefaultBackOffDuration,
-				Steps:    retrySteps,
-				Factor:   constants.DefaultBackOffFactor,
-				Jitter:   0.1,
-			}
-			err := wait.ExponentialBackoff(opts, func() (bool, error) {
-				ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
-				mresp, err := client.MemberAdd(ctx, etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
-				cancel()
-				if err != nil {
-					log.Warningf("[membership] Error adding member: %v, will retry after %s.", err, opts.Step())
-					lastErr = err
-					return false, nil
-				}
-				localMember = mresp.Member
-				members = mresp.Members
-				return true, nil
-			})
-			if err != nil {
-				log.Fatalf("[membership] Error adding member: %v", lastErr)
-			}
-		} else {
-			log.Println("[membership] Member was added")
-		}
-
-		log.Println("[membership] Checking if member was started")
-		if !etcd.Started(localMember) {
-			log.Println("[membership] Member was not started")
-			log.Printf("[membership] Removing existing data dir %q", etcdAdmConfig.DataDir)
-			os.RemoveAll(etcdAdmConfig.DataDir)
-
-			// To derive the initial cluster string, add the name and peerURLs to the local member
-			localMember.Name = etcdAdmConfig.Name
-			localMember.PeerURLs = etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice()
-
-			var desiredMembers []*etcdserverpb.Member
-			for _, m := range members {
-				if m.ID == localMember.ID {
-					continue
-				}
-				desiredMembers = append(desiredMembers, m)
-			}
-			desiredMembers = append(desiredMembers, localMember)
-			etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(desiredMembers)
-		} else {
-			log.Println("[membership] Member was started")
-			log.Printf("[membership] Keeping existing data dir %q", etcdAdmConfig.DataDir)
-			etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(members)
-		}
-
-		if err = initSystem.Install(); err != nil {
-			log.Fatalf("[install] Error: %s", err)
-		}
-		if err = initSystem.Configure(); err != nil {
-			log.Fatalf("[configure] Error: %s", err)
-		}
-		if err := initSystem.EnableAndStartService(); err != nil {
-			log.Fatalf("[start] Error: %s", err)
-		}
-		if err := service.WriteEtcdctlEnvFile(&etcdAdmConfig); err != nil {
-			log.Printf("[configure] Warning: %s", err)
-		}
-		if err := service.WriteEtcdctlShellWrapper(&etcdAdmConfig); err != nil {
-			log.Printf("[configure] Warning: %s", err)
-		}
-
-		log.Println("[health] Checking local etcd endpoint health")
-		client, err = etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
-		if err != nil {
-			log.Printf("[health] Error checking health: %v", err)
-		}
-		ctx, cancel = context.WithTimeout(context.Background(), initSystem.StartupTimeout())
-		_, err = client.Get(ctx, constants.EtcdHealthCheckKey)
-		cancel()
-		// Healthy because the cluster reaches consensus for the get request,
-		// even if permission (to get the key) is denied.
-		if err == nil || err == rpctypes.ErrPermissionDenied {
-			log.Println("[health] Local etcd endpoint is healthy")
-		} else {
-			log.Fatalf("[health] Local etcd endpoint is unhealthy: %v", err)
-		}
-	},
-}
-
 func init() {
+	runner := newJoinRunner()
+	joinCmd := newJoinCmd(runner)
 	rootCmd.AddCommand(joinCmd)
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.Name, "name", "", "etcd member name")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.Version, "version", constants.DefaultVersion, "etcd version")
@@ -194,4 +50,209 @@ func init() {
 	joinCmd.PersistentFlags().BoolVar(&etcdAdmConfig.Retry, "retry", true, "Enable or disable backoff retry when join etcd member to cluster")
 	joinCmd.PersistentFlags().StringVar((*string)(&etcdAdmConfig.InitSystem), "init-system", string(apis.Systemd), "init system type (systemd or kubelet)")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+
+	runner.registerPhasesAsSubcommands(joinCmd)
+}
+
+func newJoinCmd(runner *runner) *cobra.Command {
+	return &cobra.Command{
+		Use:   "join",
+		Short: "Join an existing etcd cluster",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runner.run(cmd, args); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+func newJoinRunner() *runner {
+	runner := newRunner(joinPhasesSetup)
+	runner.registerPhases(
+		stop(),
+		certificates(),
+		membership(),
+		joinInstall(),
+		joinConfigure(),
+		joinStart(),
+		etcdctl(),
+		healthcheck(),
+	)
+
+	return runner
+}
+
+func joinPhasesSetup(cmd *cobra.Command, args []string) (*phaseInput, error) {
+	endpoint := args[0]
+	if _, err := url.Parse(endpoint); err != nil {
+		return nil, fmt.Errorf("endpoint %q must be a valid URL: %s", endpoint, err)
+	}
+	etcdAdmConfig.Endpoint = endpoint
+
+	apis.SetDefaults(&etcdAdmConfig)
+	if err := apis.SetJoinDynamicDefaults(&etcdAdmConfig); err != nil {
+		return nil, fmt.Errorf("[defaults] error setting join dynamic defaults: %w", err)
+	}
+
+	initSystem, err := initsystem.GetInitSystem(&etcdAdmConfig)
+	if err != nil {
+		return nil, fmt.Errorf("[initsystem] error detecting the init system: %w", err)
+	}
+
+	in := &phaseInput{
+		initSystem:    initSystem,
+		etcdAdmConfig: &etcdAdmConfig,
+	}
+
+	return in, nil
+}
+
+func stop() phase {
+	return &singlePhase{
+		phaseName: "stop",
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.DisableAndStopService(); err != nil {
+				return fmt.Errorf("error disabling and stopping etcd service: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func membership() phase {
+	return &singlePhase{
+		phaseName: "membership",
+		runFunc: func(in *phaseInput) error {
+			if in.etcdAdmConfig.InitialCluster != "" {
+				// we already run this phase
+				return nil
+			}
+
+			var localMember *etcdserverpb.Member
+			var members []*etcdserverpb.Member
+			log.Println("[membership] Checking if this member was added")
+			client, err := etcd.ClientForEndpoint(in.etcdAdmConfig.Endpoint, in.etcdAdmConfig)
+			if err != nil {
+				return fmt.Errorf("error checking membership: %v", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
+			mresp, err := client.MemberList(ctx)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("error listing members: %v", err)
+			}
+			members = mresp.Members
+			localMember, ok := etcd.MemberForPeerURLs(members, in.etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
+			if !ok {
+				log.Printf("[membership] Member was not added")
+				log.Printf("Removing existing data dir %q", in.etcdAdmConfig.DataDir)
+				os.RemoveAll(in.etcdAdmConfig.DataDir)
+				log.Println("[membership] Adding member")
+
+				var lastErr error
+				retrySteps := 1
+				if in.etcdAdmConfig.Retry {
+					retrySteps = constants.DefaultBackOffSteps
+				}
+
+				// Exponential backoff for MemberAdd (values exclude jitter):
+				// If --retry=false, add member only try one times, otherwise try five times.
+				// The backoff duration is 0, 2, 4, 8, 16 s
+				opts := wait.Backoff{
+					Duration: constants.DefaultBackOffDuration,
+					Steps:    retrySteps,
+					Factor:   constants.DefaultBackOffFactor,
+					Jitter:   0.1,
+				}
+				err := wait.ExponentialBackoff(opts, func() (bool, error) {
+					ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
+					mresp, err := client.MemberAdd(ctx, in.etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
+					cancel()
+					if err != nil {
+						log.Warningf("[membership] Error adding member: %v, will retry after %s.", err, opts.Step())
+						lastErr = err
+						return false, nil
+					}
+					localMember = mresp.Member
+					members = mresp.Members
+					return true, nil
+				})
+				if err != nil {
+					return fmt.Errorf("error adding member: %v", lastErr)
+				}
+			} else {
+				log.Println("[membership] Member was added")
+			}
+
+			log.Println("[membership] Checking if member was started")
+			if !etcd.Started(localMember) {
+				log.Println("[membership] Member was not started")
+				log.Printf("[membership] Removing existing data dir %q", in.etcdAdmConfig.DataDir)
+				os.RemoveAll(in.etcdAdmConfig.DataDir)
+
+				// To derive the initial cluster string, add the name and peerURLs to the local member
+				localMember.Name = in.etcdAdmConfig.Name
+				localMember.PeerURLs = in.etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice()
+
+				var desiredMembers []*etcdserverpb.Member
+				for _, m := range members {
+					if m.ID == localMember.ID {
+						continue
+					}
+					desiredMembers = append(desiredMembers, m)
+				}
+				desiredMembers = append(desiredMembers, localMember)
+				in.etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(desiredMembers)
+			} else {
+				log.Println("[membership] Member was started")
+				log.Printf("[membership] Keeping existing data dir %q", in.etcdAdmConfig.DataDir)
+				in.etcdAdmConfig.InitialCluster = etcd.InitialClusterFromMembers(members)
+			}
+
+			return nil
+		},
+	}
+}
+
+func joinInstall() phase {
+	return &singlePhase{
+		phaseName: "install",
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.Install(); err != nil {
+				return fmt.Errorf("failed installing init system components: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func joinConfigure() phase {
+	return &singlePhase{
+		phaseName:     "configure",
+		prerequisites: []phase{membership()},
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.Configure(); err != nil {
+				return fmt.Errorf("error configuring init system: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func joinStart() phase {
+	return &singlePhase{
+		phaseName:     "start",
+		prerequisites: []phase{membership()},
+		runFunc: func(in *phaseInput) error {
+			if err := in.initSystem.EnableAndStartService(); err != nil {
+				return fmt.Errorf("error starting etcd: %w", err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/cmd/phases.go
+++ b/cmd/phases.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/etcdadm/apis"
+	"sigs.k8s.io/etcdadm/initsystem"
+	log "sigs.k8s.io/etcdadm/pkg/logrus"
+)
+
+type phaseInput struct {
+	initSystem    initsystem.InitSystem
+	etcdAdmConfig *apis.EtcdAdmConfig
+}
+
+type runFunc func(*phaseInput) error
+
+type phase interface {
+	name() string
+	run(*phaseInput) error
+	registerInCommand(cmd *cobra.Command, runner *runner)
+}
+
+type singlePhase struct {
+	phaseName string
+	runFunc  runFunc
+}
+
+func (p *singlePhase) name() string {
+	return p.phaseName
+}
+
+func (p *singlePhase) run(phaseInput *phaseInput) error {
+	return p.runFunc(phaseInput)
+}
+
+func (p *singlePhase) registerInCommand(cmd *cobra.Command, runner *runner) {
+	phaseCmd := &cobra.Command{
+		Use:   p.phaseName,
+		Short: fmt.Sprintf("Run %s phase", p.phaseName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runner.runPhases(p); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	cmd.AddCommand(phaseCmd)
+}
+
+type initFunc func() (*phaseInput, error)
+
+type runner struct {
+	phases []phase
+	init   initFunc
+}
+
+func newRunner(init initFunc) *runner {
+	return &runner{
+		phases: make([]phase, 0),
+		init:   init,
+	}
+}
+
+func (r *runner) registerPhases(phases ...phase) {
+	r.phases = append(r.phases, phases...)
+}
+
+func (r *runner) run() error {
+	return r.runPhases(r.phases...)
+}
+
+func (r *runner) runPhases(phases ...phase) error {
+	phaseInput, err := r.init()
+	if err != nil {
+		return err
+	}
+
+	for _, phase := range phases {
+		if err := phase.run(phaseInput); err != nil {
+			return fmt.Errorf("[%s] %s", phase.name(), err)
+		}
+	}
+
+	return nil
+}
+
+func (r *runner) registerPhasesAsSubcommands(cmd *cobra.Command) {
+	phaseCmd := &cobra.Command{
+		Use:   "phase",
+		Short: fmt.Sprintf("Use this command to invoke single phase of the %s command", cmd.Name()),
+	}
+
+	for _, phase := range r.phases {
+		phase.registerInCommand(phaseCmd, r)
+	}
+
+	cmd.AddCommand(phaseCmd)
+}

--- a/test/e2e/cluster_phases.sh
+++ b/test/e2e/cluster_phases.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+
+DATA_VOLUME_NAME="etcdadm-volume"
+DATA_VOLUME_MOUNT_PATH="/opt/etcd/pki"
+IMAGE="kindest/node:v1.16.2"
+
+cd_root_path
+
+if [ ! -f ./etcdadm ]; then
+    echo "etcdadm binary not found. Run 'make container-build' first"
+    exit 1
+fi
+
+# Prepare containers
+trap "docker rm -f etcdadm-{0,1,2};docker volume rm ${DATA_VOLUME_NAME}" EXIT
+
+# Prepare etcdadm CA certificates temporary local volume
+docker volume create ${DATA_VOLUME_NAME}
+
+for ((i=0;i<3;i++))
+do
+    docker run --name etcdadm-${i} --detach --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume ${DATA_VOLUME_NAME}:${DATA_VOLUME_MOUNT_PATH} --volume ${PWD}:/etcdadm ${IMAGE}
+done
+
+# Run init
+docker exec etcdadm-0 /etcdadm/etcdadm init phase install
+docker exec etcdadm-0 /etcdadm/etcdadm init phase certificates
+docker exec etcdadm-0 /etcdadm/etcdadm init phase snapshot
+docker exec etcdadm-0 /etcdadm/etcdadm init phase configure
+docker exec etcdadm-0 /etcdadm/etcdadm init phase start
+docker exec etcdadm-0 /etcdadm/etcdadm init phase etcdctl
+docker exec etcdadm-0 /etcdadm/etcdadm init phase health
+docker exec etcdadm-0 /etcdadm/etcdadm init phase post-init-instructions
+
+# Verify that all endpoints are healthy
+docker exec etcdadm-0 /opt/bin/etcdctl.sh endpoint health
+
+# Verify the init container ip address
+etcdadm_0_ip=$(docker inspect --format {{.NetworkSettings.Networks.bridge.IPAddress}} etcdadm-0)
+
+# Copy CA certs from etcdadm-0 container to bin directory
+docker exec etcdadm-0 cp /etc/etcd/pki/ca.crt ${DATA_VOLUME_MOUNT_PATH}/
+docker exec etcdadm-0 cp /etc/etcd/pki/ca.key ${DATA_VOLUME_MOUNT_PATH}/
+
+# Add more members
+for ((i=1;i<3;i++))
+do
+    echo "Copying CA certs to container etcdadm-${i}"
+    # Copy CA certs to container
+    # Copy CA certs to container
+    docker exec etcdadm-${i} mkdir -p /etc/etcd/
+    docker exec etcdadm-${i} cp -r ${DATA_VOLUME_MOUNT_PATH} /etc/etcd/pki
+
+    echo "Joining etcd member etcdadm-${i}"
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase stop https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase certificates https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase membership https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase install https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase configure https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase start https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase etcdctl https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+    docker exec etcdadm-${i} /etcdadm/etcdadm join phase health https://${etcdadm_0_ip}:2379 --name etcdadm-${i}
+
+
+    docker exec etcdadm-${i} /opt/bin/etcdctl.sh endpoint health --cluster -w table
+
+    sleep 5
+done
+
+# Verify that all endpoints are healthy
+echo "Etcd cluster members:"
+docker exec etcdadm-0 /opt/bin/etcdctl.sh endpoint health --cluster -w table


### PR DESCRIPTION
This adds the ability to run the init and join command in phases, very much inspired by `kubeadm`. This is very useful when having non conventional setups, where extra operations need to be done at some point during the workflow (for example, when using bottlerocket).

The implementation is very simple, it doesn't allow for most of the fancy stuff the `kubeadm` one does.
This can only run one phase at a time.
It makes the assumption that all phases are idempotent.
Phases can be run as sub-commands for the init and join commands:
```sh
etcdadm init phase --help
Use this command to invoke single phase of the init command

Usage:
  etcdadm init phase [command]

Available Commands:
  certificates           Run certificates phase
  configure              Run configure phase
  etcdctl                Run etcdctl phase
  health                 Run health phase
  install                Run install phase
  post-init-instructions Run post-init-instructions phase
  snapshot               Run snapshot phase
  start                  Run start phase
```

```sh
etcdadm join phase --help
Use this command to invoke single phase of the join command

Usage:
  etcdadm join phase [command]

Available Commands:
  certificates Run certificates phase
  configure    Run configure phase
  etcdctl      Run etcdctl phase
  health       Run health phase
  install      Run install phase
  membership   Run membership phase
  start        Run start phase
  stop         Run stop phase
```