### PR TITLE
Use latest etcd versions for the upgrade/downgrade test

### DIFF
--- a/etcd-manager/pkg/etcdversions/mappings.go
+++ b/etcd-manager/pkg/etcdversions/mappings.go
@@ -50,6 +50,14 @@ var AllEtcdVersions = []string{
 	Version_3_5_0,
 }
 
+var LatestEtcdVersions = []string{
+	Version_3_1_12,
+	Version_3_2_24,
+	Version_3_3_17,
+	Version_3_4_13,
+	Version_3_5_0,
+}
+
 func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
 	fromSemver, err := semver.ParseTolerant(fromVersion)
 	if err != nil {

--- a/etcd-manager/test/integration/upgradedowngrade/upgradedowngrade_test.go
+++ b/etcd-manager/test/integration/upgradedowngrade/upgradedowngrade_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestUpgradeDowngrade(t *testing.T) {
-	for _, fromVersion := range etcdversions.AllEtcdVersions {
-		for _, toVersion := range etcdversions.AllEtcdVersions {
+	for _, fromVersion := range etcdversions.LatestEtcdVersions {
+		for _, toVersion := range etcdversions.LatestEtcdVersions {
 			if fromVersion == toVersion {
 				continue
 			}


### PR DESCRIPTION
Will make the upgrade/downgrade test faster, as discussed during kOps office hours.