### PR TITLE
Detect if etcd exits during dump/restore operations

### DIFF
--- a/etcd-manager/cmd/etcd-dump/main.go
+++ b/etcd-manager/cmd/etcd-dump/main.go
@@ -117,10 +117,16 @@ func runDump(backupFile string, out string) error {
 
 	for i := 0; i < 60; i++ {
 		ctx := context.TODO()
-		_, err := sourceClient.Get(ctx, "/", true)
+		_, err := sourceClient.Get(ctx, "/", true, 2*time.Second)
 		if err == nil {
 			break
 		}
+
+		exitError, exitState := process.ExitState()
+		if exitError != nil || exitState != nil {
+			return fmt.Errorf("etcd process exited (state=%v): %w", exitState, exitError)
+		}
+
 		klog.Infof("Waiting for etcd to start (%v)", err)
 		time.Sleep(time.Second)
 	}

--- a/etcd-manager/pkg/controller/etcdclusterstate.go
+++ b/etcd-manager/pkg/controller/etcdclusterstate.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 	protoetcd "sigs.k8s.io/etcdadm/etcd-manager/pkg/apis/etcd"
@@ -176,7 +177,7 @@ func (s *etcdClusterState) etcdGet(ctx context.Context, key string) ([]byte, err
 			continue
 		}
 
-		response, err := etcdClient.Get(ctx, key, true)
+		response, err := etcdClient.Get(ctx, key, true, 2*time.Second)
 		etcdclient.LoggedClose(etcdClient)
 		if err != nil {
 			klog.Warningf("error reading from member %s: %v", member, err)

--- a/etcd-manager/pkg/etcdclient/client.go
+++ b/etcd-manager/pkg/etcdclient/client.go
@@ -137,7 +137,10 @@ func (c *EtcdClient) ServerVersion(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("could not fetch server version")
 }
 
-func (c *EtcdClient) Get(ctx context.Context, key string, quorum bool) ([]byte, error) {
+func (c *EtcdClient) Get(ctx context.Context, key string, quorum bool, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	var opts []etcd_client_v3.OpOption
 	if quorum {
 		// Quorum is the default in etcd3

--- a/etcd-manager/test/integration/harness/etcd.go
+++ b/etcd-manager/test/integration/harness/etcd.go
@@ -40,7 +40,7 @@ func (n *TestHarnessNode) get(ctx context.Context, key string, quorum bool) (str
 	}
 	defer client.Close()
 
-	response, err := client.Get(ctx, key, quorum)
+	response, err := client.Get(ctx, key, quorum, 2*time.Second)
 	if err != nil {
 		return "", fmt.Errorf("error reading from member %s: %v", n.ClientURL, err)
 	}


### PR DESCRIPTION
We need to explicitly specify a timeout on get operations, so that we
can detect if etcd exits.