### PR TITLE
Use unixs for "restore source" endpoint

### DIFF
--- a/etcd-manager/pkg/etcd/pki.go
+++ b/etcd-manager/pkg/etcd/pki.go
@@ -146,6 +146,10 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 				certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, ip)
 			}
 
+		case "unix", "unixs":
+			h := u.Hostname() // Hostname does not include port
+			certConfig.AltNames.DNSNames = append(certConfig.AltNames.DNSNames, h)
+
 		default:
 			return fmt.Errorf("unknown URL %q", urlString)
 		}


### PR DESCRIPTION
When restoring a backup for both etcd and etcd-events, I observed a
port-conflict on port 8002/8003.  Switching to unixs:// endpoints (unix
domain sockets) is a little more secure, and avoids the port conflict.

Due to https://github.com/etcd-io/etcd/issues/12450 the syntax is
slightly awkward - we have to make it look like a host and port.