### PR TITLE
etcd-manager - Allow all 3.X upgrades of one minor version

### DIFF
--- a/etcd-manager/pkg/etcdversions/mappings.go
+++ b/etcd-manager/pkg/etcdversions/mappings.go
@@ -72,31 +72,7 @@ func UpgradeInPlaceSupported(fromVersion, toVersion string) bool {
 	}
 
 	if fromSemver.Major == 3 && toSemver.Major == 3 {
-		if fromSemver.Minor == 0 && toSemver.Minor == 0 {
-			return true
-		}
-		if fromSemver.Minor == 0 && toSemver.Minor == 1 {
-			return true
-		}
-		if fromSemver.Minor == 1 && toSemver.Minor == 1 {
-			return true
-		}
-		if fromSemver.Minor == 1 && toSemver.Minor == 2 {
-			return true
-		}
-		if fromSemver.Minor == 2 && toSemver.Minor == 2 {
-			return true
-		}
-		if fromSemver.Minor == 2 && toSemver.Minor == 3 {
-			return true
-		}
-		if fromSemver.Minor == 3 && toSemver.Minor == 3 {
-			return true
-		}
-		if fromSemver.Minor == 3 && toSemver.Minor == 4 {
-			return true
-		}
-		if fromSemver.Minor == 4 && toSemver.Minor == 4 {
+		if toSemver.Minor-fromSemver.Minor <= 1 && toSemver.Minor >= fromSemver.Minor {
 			return true
 		}
 	}


### PR DESCRIPTION
This is a bit more future-proof and lower maintenance. This should cover all 3.X upgrades of up to one minor version.

ref: https://github.com/kubernetes/kops/issues/12662