### PR TITLE
staging builds: compute our own version

### DIFF
--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -15,7 +15,8 @@ steps:
 - name: gcr.io/k8s-testimages/krte:latest-master
   env:
   - PULL_BASE_REF=$_PULL_BASE_REF
-  - VERSION=$_GIT_TAG
+  # We don't pass version; we want to use our own version tagging from git
+  #- VERSION=$_GIT_TAG
   - DOCKER_REGISTRY=$_DOCKER_REGISTRY
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   - ARTIFACT_LOCATION=$_ARTIFACT_LOCATION


### PR DESCRIPTION
The version that is passed to us includes a date prefix, so we need to
compute our own tag.

Do this (initially) for etcd-manager only.