### PR TITLE
Remove the service arg from InitSystem

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -47,7 +47,7 @@ var initCmd = &cobra.Command{
 			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
 		}
 
-		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+		if err := initSystem.DisableAndStopService(); err != nil {
 			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
 		}
 
@@ -75,7 +75,7 @@ var initCmd = &cobra.Command{
 		if err = initSystem.Configure(); err != nil {
 			log.Fatalf("[configure] Error: %s", err)
 		}
-		if err = initSystem.EnableAndStartService(constants.UnitFileBaseName); err != nil {
+		if err = initSystem.EnableAndStartService(); err != nil {
 			log.Fatalf("[start] Error: %s", err)
 		}
 		if err = service.WriteEtcdctlEnvFile(&etcdAdmConfig); err != nil {

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -57,7 +57,7 @@ var joinCmd = &cobra.Command{
 			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
 		}
 
-		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+		if err := initSystem.DisableAndStopService(); err != nil {
 			log.Fatalf("[install] Error disabling and stopping etcd service: %s", err)
 		}
 
@@ -153,7 +153,7 @@ var joinCmd = &cobra.Command{
 		if err = initSystem.Configure(); err != nil {
 			log.Fatalf("[configure] Error: %s", err)
 		}
-		if err := initSystem.EnableAndStartService(constants.UnitFileBaseName); err != nil {
+		if err := initSystem.EnableAndStartService(); err != nil {
 			log.Fatalf("[start] Error: %s", err)
 		}
 		if err := service.WriteEtcdctlEnvFile(&etcdAdmConfig); err != nil {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -49,7 +49,7 @@ var resetCmd = &cobra.Command{
 			log.Fatalf("[initsystem] Error detecting the init system: %s", err)
 		}
 
-		active, err := initSystem.IsActive(constants.UnitFileBaseName)
+		active, err := initSystem.IsActive()
 		if err != nil {
 			log.Fatalf("[reset] Error checking if etcd service is active: %s", err)
 		}
@@ -91,7 +91,7 @@ var resetCmd = &cobra.Command{
 				}
 			}
 		}
-		if err := initSystem.DisableAndStopService(constants.UnitFileBaseName); err != nil {
+		if err := initSystem.DisableAndStopService(); err != nil {
 			log.Fatalf("[reset] Error stopping etcd: %s", err)
 		}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -28,10 +28,9 @@ const (
 	DefaultBindAddressv4   = "0.0.0.0"
 	DefaultCertificateDir  = "/etc/etcd/pki"
 
-	UnitFileBaseName = "etcd.service"
-	UnitFile         = "/etc/systemd/system/etcd.service"
-	EnvironmentFile  = "/etc/etcd/etcd.env"
-	EtcdctlEnvFile   = "/etc/etcd/etcdctl.env"
+	UnitFile        = "/etc/systemd/system/etcd.service"
+	EnvironmentFile = "/etc/etcd/etcd.env"
+	EtcdctlEnvFile  = "/etc/etcd/etcdctl.env"
 
 	DefaultDataDir = "/var/lib/etcd"
 

--- a/initsystem/initsystem.go
+++ b/initsystem/initsystem.go
@@ -29,9 +29,9 @@ import (
 type InitSystem interface {
 	Install() error
 	Configure() error
-	IsActive(service string) (bool, error)
-	EnableAndStartService(service string) error
-	DisableAndStopService(service string) error
+	IsActive() (bool, error)
+	EnableAndStartService() error
+	DisableAndStopService() error
 	StartupTimeout() time.Duration
 }
 

--- a/initsystem/kubelet/initsystem.go
+++ b/initsystem/kubelet/initsystem.go
@@ -45,7 +45,7 @@ type InitSystem struct {
 }
 
 // EnableAndStartService enables and starts the etcd service
-func (s *InitSystem) EnableAndStartService(service string) error {
+func (s *InitSystem) EnableAndStartService() error {
 	cfg := s.desiredConfig
 
 	name := s.name(cfg)
@@ -77,7 +77,7 @@ func (s *InitSystem) EnableAndStartService(service string) error {
 }
 
 // DisableAndStopService disables and stops the etcd service
-func (s *InitSystem) DisableAndStopService(service string) error {
+func (s *InitSystem) DisableAndStopService() error {
 	podFile := s.podFile(s.desiredConfig)
 	if err := os.Remove(podFile); err != nil {
 		if os.IsNotExist(err) {
@@ -91,7 +91,7 @@ func (s *InitSystem) DisableAndStopService(service string) error {
 }
 
 // IsActive checks if the systemd unit is active
-func (s *InitSystem) IsActive(service string) (bool, error) {
+func (s *InitSystem) IsActive() (bool, error) {
 	podFile := s.podFile(s.desiredConfig)
 	_, err := os.Stat(podFile)
 	if err != nil {


### PR DESCRIPTION
It was only passed a constant value, and arguably the wrong value if
the user overrides the UnitFile.

Fixing this moves us closer to reuse of the InitSystem.