### PR TITLE
Fix .gitignore to not ignore vendoring

### DIFF
--- a/etcd-manager/.gitignore
+++ b/etcd-manager/.gitignore
@@ -20,4 +20,4 @@ bazel-testlogs
 dist/
 
 # Don't ignore vendoring
-!vendor
+!vendor/**


### PR DESCRIPTION
We have to specify the wildcard blob to get git to process this
correctly.
