### PR TITLE
Add support for listening to IPv6

### DIFF
--- a/etcd-manager/cmd/etcd-manager/main.go
+++ b/etcd-manager/cmd/etcd-manager/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -342,7 +343,7 @@ func RunEtcdManager(o *EtcdManagerOptions) error {
 		o.Address = "127.0.0.1"
 	}
 
-	grpcEndpoint := fmt.Sprintf("%s:%d", o.Address, o.GrpcPort)
+	grpcEndpoint := net.JoinHostPort(o.Address, strconv.Itoa(o.GrpcPort))
 
 	if discoveryProvider == nil {
 		discoMe := discovery.Node{

--- a/etcd-manager/pkg/controller/controller.go
+++ b/etcd-manager/pkg/controller/controller.go
@@ -621,10 +621,6 @@ func (m *EtcdController) buildMemberMap(etcdClusterState *etcdClusterState) *pro
 
 		for _, a := range peer.peer.info.Endpoints {
 			ip := a
-			colonIndex := strings.Index(ip, ":")
-			if colonIndex != -1 {
-				ip = ip[:colonIndex]
-			}
 			memberInfo.Addresses = append(memberInfo.Addresses, ip)
 		}
 

--- a/etcd-manager/pkg/controller/newcluster.go
+++ b/etcd-manager/pkg/controller/newcluster.go
@@ -102,10 +102,6 @@ func (m *EtcdController) createNewCluster(ctx context.Context, clusterState *etc
 
 		for _, a := range p.peer.info.Endpoints {
 			ip := a
-			colonIndex := strings.Index(ip, ":")
-			if colonIndex != -1 {
-				ip = ip[:colonIndex]
-			}
 			memberInfo.Addresses = append(memberInfo.Addresses, ip)
 		}
 

--- a/etcd-manager/pkg/etcd/etcdprocess.go
+++ b/etcd-manager/pkg/etcd/etcdprocess.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -329,7 +330,7 @@ func changeHost(urls []string, host string) []string {
 		}
 		newHost := host
 		if u.Port() != "" {
-			newHost += ":" + u.Port()
+			newHost = net.JoinHostPort(newHost, u.Port())
 		}
 		u.Host = newHost
 		remapped = append(remapped, u.String())

--- a/etcd-manager/pkg/etcd/etcdserver.go
+++ b/etcd-manager/pkg/etcd/etcdserver.go
@@ -239,7 +239,11 @@ func (s *EtcdServer) UpdateEndpoints(ctx context.Context, request *protoetcd.Upd
 		for _, m := range request.MemberMap.Members {
 			if m.Dns != "" {
 				for _, a := range m.Addresses {
-					addressToHosts[a] = append(addressToHosts[a], m.Dns)
+					ip, _, err := net.SplitHostPort(a)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse address %s: %v", a, err)
+					}
+					addressToHosts[ip] = append(addressToHosts[ip], m.Dns)
 				}
 			}
 		}

--- a/etcd-manager/pkg/etcd/pki.go
+++ b/etcd-manager/pkg/etcd/pki.go
@@ -163,6 +163,13 @@ func addAltNames(certConfig *certutil.Config, urls []string) error {
 		}
 	}
 	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("127.0.0.1"))
+	for _, ip := range certConfig.AltNames.IPs {
+		if ip.String() == "::1" {
+			return nil
+		}
+	}
+	certConfig.AltNames.IPs = append(certConfig.AltNames.IPs, net.ParseIP("::1"))
+
 	return nil
 }
 

--- a/etcd-manager/pkg/privateapi/peers.go
+++ b/etcd-manager/pkg/privateapi/peers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -310,7 +311,7 @@ func (p *peer) connect() (*grpc.ClientConn, error) {
 			if port == 0 {
 				port = p.defaultPort
 			}
-			s := fmt.Sprintf("%s:%v", endpoint.IP, port)
+			s := net.JoinHostPort(endpoint.IP, strconv.Itoa(port))
 			endpoints[s] = true
 		}
 

--- a/etcd-manager/pkg/volumes/aws/volumes.go
+++ b/etcd-manager/pkg/volumes/aws/volumes.go
@@ -103,11 +103,19 @@ func NewAWSVolumes(clusterName string, volumeTags []string, nameTag string) (*AW
 		return nil, fmt.Errorf("error querying ec2 metadata service (for instance-id): %v", err)
 	}
 
-	a.localIP, err = a.metadata.GetMetadata("local-ipv4")
-	if err != nil {
-		return nil, fmt.Errorf("error querying ec2 metadata service (for local-ipv4): %v", err)
+	hostnameBytes, err := a.metadata.GetMetadata("local-hostname")
+	hostname := string(hostnameBytes)
+	if strings.HasPrefix(hostname, "i-") {
+		a.localIP, err = a.metadata.GetMetadata("ipv6")
+		if err != nil {
+			return nil, fmt.Errorf("error querying ec2 metadata service (ipv6): %v", err)
+		}
+	} else {
+		a.localIP, err = a.metadata.GetMetadata("local-ipv4")
+		if err != nil {
+			return nil, fmt.Errorf("error querying ec2 metadata service (for local-ipv4): %v", err)
+		}
 	}
-
 	a.ec2 = ec2.New(s, config.WithRegion(region))
 
 	return a, nil


### PR DESCRIPTION
If instances are using Resource Based Naming, we are guaranteed to have ipv6 addresses and we use them between etcd-manager instances.

This will also make etcd-manager work in ipv6-native/only subnets.

This PR also makes it possible for etcd-manager to create an etcd cluster listening on ipv6, but the default remains listening on ipv4.

This PR is tested in https://github.com/kubernetes/kops/pull/12855