### PR TITLE
Cert renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ On the machine being removed, run
 etcdadm reset
 ```
 
+### Renewal certificates
+
+1. Ensure the CA certificate and key already exists on the machine.
+
+If not exists, Copy the CA certificate and key from other machine in the cluster.
+
+```
+rsync -avR /etc/etcd/pki/ca.* <Member IP address>:/
+```
+
+2. run command to renew certficates via CA certificate and key.
+
+```
+etcdadm certs renew
+```
+
 ## Advanced Usage
 
 ### Creating a new cluster from a snapshot

--- a/certs/pkiutil/pki_helpers.go
+++ b/certs/pkiutil/pki_helpers.go
@@ -29,6 +29,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
+	"math"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -38,8 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
-	"math"
-	"math/big"
 	"sigs.k8s.io/etcdadm/apis"
 	"sigs.k8s.io/etcdadm/constants"
 )
@@ -183,6 +184,19 @@ func TryLoadCertAndKeyFromDisk(pkiPath, name string) (*x509.Certificate, *rsa.Pr
 	}
 
 	return cert, key, nil
+}
+
+// TryLoadCertFromDiskIgnoreExpirationDate tries to load the cert from the disk and ignore expiration date
+func TryLoadCertFromDiskIgnoreExpirationDate(pkiPath, name string) (*x509.Certificate, error) {
+	certificatePath := pathForCert(pkiPath, name)
+
+	certs, err := certutil.CertsFromFile(certificatePath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load the certificate file %s: %v", certificatePath, err)
+	}
+
+	// We are only putting one certificate in the certificate pem file, so it's safe to just pick the first one
+	return certs[0], nil
 }
 
 // TryLoadCertFromDisk tries to load the cert from the disk and validates that it is valid
@@ -385,4 +399,129 @@ func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}
 	return pem.EncodeToMemory(&block)
+}
+
+// NewCSRAndKey generates a new key and CSR and that could be signed to create the given certificate
+func NewCSRAndKey(config *certutil.Config) (*x509.CertificateRequest, *rsa.PrivateKey, error) {
+	key, err := NewPrivateKey()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to create private key")
+	}
+
+	csr, err := NewCSR(*config, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to generate CSR")
+	}
+
+	return csr, key, nil
+}
+
+// NewCSR creates a new CSR
+func NewCSR(cfg certutil.Config, key crypto.Signer) (*x509.CertificateRequest, error) {
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:    cfg.AltNames.DNSNames,
+		IPAddresses: cfg.AltNames.IPs,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(cryptorand.Reader, template, key)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a CSR")
+	}
+
+	return x509.ParseCertificateRequest(csrBytes)
+}
+
+func pathForCSR(pkiPath, name string) string {
+	return filepath.Join(pkiPath, fmt.Sprintf("%s.csr", name))
+}
+
+// CSROrKeyExist returns true if one of the CSR or key exists
+func CSROrKeyExist(csrDir, name string) bool {
+	csrPath := pathForCSR(csrDir, name)
+	keyPath := pathForKey(csrDir, name)
+
+	_, csrErr := os.Stat(csrPath)
+	_, keyErr := os.Stat(keyPath)
+
+	return !(os.IsNotExist(csrErr) && os.IsNotExist(keyErr))
+}
+
+func parseCSRPEM(pemCSR []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode(pemCSR)
+	if block == nil {
+		return nil, errors.New("data doesn't contain a valid certificate request")
+	}
+
+	if block.Type != certutil.CertificateRequestBlockType {
+		return nil, errors.Errorf("expected block type %q, but PEM had type %q", certutil.CertificateRequestBlockType, block.Type)
+	}
+
+	return x509.ParseCertificateRequest(block.Bytes)
+}
+
+// CertificateRequestFromFile returns the CertificateRequest from a given PEM-encoded file.
+// Returns an error if the file could not be read or if the CSR could not be parsed.
+func CertificateRequestFromFile(file string) (*x509.CertificateRequest, error) {
+	pemBlock, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read file")
+	}
+
+	csr, err := parseCSRPEM(pemBlock)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading certificate request file %s", file)
+	}
+	return csr, nil
+}
+
+// TryLoadCSRAndKeyFromDisk tries to load the CSR and key from the disk
+func TryLoadCSRAndKeyFromDisk(pkiPath, name string) (*x509.CertificateRequest, crypto.Signer, error) {
+	csrPath := pathForCSR(pkiPath, name)
+
+	csr, err := CertificateRequestFromFile(csrPath)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "couldn't load the certificate request %s", csrPath)
+	}
+
+	key, err := TryLoadKeyFromDisk(pkiPath, name)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't load key file")
+	}
+
+	return csr, key, nil
+}
+
+// EncodeCSRPEM returns PEM-encoded CSR data
+func EncodeCSRPEM(csr *x509.CertificateRequest) []byte {
+	block := pem.Block{
+		Type:  certutil.CertificateRequestBlockType,
+		Bytes: csr.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+// WriteCSR writes the pem-encoded CSR data to csrPath.
+// The CSR file will be created with file mode 0600.
+// If the CSR file already exists, it will be overwritten.
+// The parent directory of the csrPath will be created as needed with file mode 0700.
+func WriteCSR(csrDir, name string, csr *x509.CertificateRequest) error {
+	if csr == nil {
+		return errors.New("certificate request cannot be nil when writing to file")
+	}
+
+	csrPath := pathForCSR(csrDir, name)
+	if err := os.MkdirAll(filepath.Dir(csrPath), os.FileMode(0700)); err != nil {
+		return errors.Wrapf(err, "failed to make directory %s", filepath.Dir(csrPath))
+	}
+
+	if err := ioutil.WriteFile(csrPath, EncodeCSRPEM(csr), os.FileMode(0600)); err != nil {
+		return errors.Wrapf(err, "unable to write CSR to file %s", csrPath)
+	}
+
+	return nil
 }

--- a/certs/pkiutil/pki_helpers_test.go
+++ b/certs/pkiutil/pki_helpers_test.go
@@ -307,6 +307,56 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 	}
 }
 
+func TestTryLoadCertFromDiskIgnoreExpirationDate(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	caCert, _, err := NewCertificateAuthority()
+	if err != nil {
+		t.Errorf(
+			"failed to create cert and key with an error: %v",
+			err,
+		)
+	}
+	err = WriteCert(tmpdir, "foo", caCert)
+	if err != nil {
+		t.Errorf(
+			"failed to write cert and key with an error: %v",
+			err,
+		)
+	}
+
+	var tests = []struct {
+		path     string
+		name     string
+		expected bool
+	}{
+		{
+			path:     "",
+			name:     "",
+			expected: false,
+		},
+		{
+			path:     tmpdir,
+			name:     "foo",
+			expected: true,
+		},
+	}
+	for _, rt := range tests {
+		_, actual := TryLoadCertFromDiskIgnoreExpirationDate(rt.path, rt.name)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed TryLoadCertFromDiskIgnoreExpirationDate:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}
+
 func TestTryLoadCertFromDisk(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/etcdadm/certs"
+	"sigs.k8s.io/etcdadm/constants"
+	log "sigs.k8s.io/etcdadm/pkg/logrus"
+)
+
+// newCmdCerts returns main command for certs phase
+func newCmdCerts() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "certs",
+		Short: "Commands related to handling etcdadm certificates",
+	}
+
+	cmd.AddCommand(newCmdCertsRenewal())
+
+	return cmd
+}
+
+func newCmdCertsRenewal() *cobra.Command {
+	var certificatesDir string
+	var csrOnly bool
+	cmd := &cobra.Command{
+		Use:   "renew",
+		Short: "Renew certificates for a etcd cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, name := range certs.GetDefaultCertList() {
+				log.Printf("[renew] Renew etcd %s certificate.", name)
+				renewed, err := certs.RenewUsingLocalCA(certificatesDir, name, csrOnly)
+				if err != nil {
+					log.Fatalf("[renew] Error renew certificate %s: %v", name, err)
+				}
+				if !renewed {
+					log.Fatalf("Certificates %s can't be renewed.\n", name)
+				}
+			}
+			log.Println("The etcd certificates have been renewed successfully!")
+			log.Warnln("If kube-apiserver which version less than v1.10.0 is running, restart it so that it uses the renewed etcd client certificate.")
+		},
+	}
+	cmd.PersistentFlags().StringVar(&certificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
+	cmd.PersistentFlags().BoolVar(&csrOnly, "csr-only", false, "create CSRs instead of generating certificates")
+
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newCmdCerts())
+}

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -38,13 +38,21 @@ func newCmdCerts() *cobra.Command {
 func newCmdCertsRenewal() *cobra.Command {
 	var certificatesDir string
 	var csrOnly bool
+	var csrDir string
 	cmd := &cobra.Command{
 		Use:   "renew",
 		Short: "Renew certificates for a etcd cluster",
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range certs.GetDefaultCertList() {
 				log.Printf("[renew] Renew etcd %s certificate.", name)
-				renewed, err := certs.RenewUsingLocalCA(certificatesDir, name, csrOnly)
+				var renewed bool
+				var err error
+				if csrOnly {
+					renewed, err = certs.RenewCSRUsingLocalCA(certificatesDir, name, csrDir)
+				} else {
+					renewed, err = certs.RenewUsingLocalCA(certificatesDir, name)
+				}
+
 				if err != nil {
 					log.Fatalf("[renew] Error renew certificate %s: %v", name, err)
 				}
@@ -58,6 +66,7 @@ func newCmdCertsRenewal() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&certificatesDir, "certs-dir", constants.DefaultCertificateDir, "certificates directory")
 	cmd.PersistentFlags().BoolVar(&csrOnly, "csr-only", false, "create CSRs instead of generating certificates")
+	cmd.PersistentFlags().StringVar(&csrDir, "csr-dir", "./", "directory to output CSRs to")
 
 	return cmd
 }


### PR DESCRIPTION
This is continuing the work from https://github.com/kubernetes-sigs/etcdadm/pull/147 done by @pytimer. 
If it is preferred this continuation is done a different way, please let me know. Essentially this feature would
be really helpful for myself, and I found the time to dig into it.

Last concern was about an issues with CSR generation. This was due to trying to write the
CSR and key to the certificate directory. When calling TryLoadCSRAndKeyFromDisk it registered
the key existed, and tried to load both. This caused the error stating it couldn't load the
CSR.

As with kubeadm, this needed a directory to output the csr specifically. I added a new argument
of csr-dir (with a default of the local directory). I split the RenewUsingLocalCA function into two
functions. One for the CSRs, and one for the full certificates. The new RenewCSRUsingLocalCA
function uses the new csr-dir path to output the CSRs. This ensures the key, from the cert being
used, is not overwritten/cause the process to fail.