### PR TITLE
staging build: increase timeout to 30 minutes

### DIFF
--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -1,7 +1,9 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
+
 steps:
 - name: gcr.io/k8s-testimages/krte:latest-master
   env:


### PR DESCRIPTION
We are now seeing timeouts with the 10 minute default; raise to 30
minutes.  We aren't running the tests, so 30 minutes should be plenty.