### PR TITLE
Add bazelversion file to tools/deb-tools

### DIFF
--- a/etcd-manager/tools/deb-tools/.bazelversion
+++ b/etcd-manager/tools/deb-tools/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion


### PR DESCRIPTION
Otherwise we don't lock in the bazel version.