### PR TITLE
Only emit GOMAXPROCS if non-zero

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -128,7 +128,7 @@ ETCD_TRUSTED_CA_FILE={{ .TrustedCAFile }}
 # Other
 ETCD_DATA_DIR={{ .DataDir }}
 ETCD_STRICT_RECONFIG_CHECK=true
-GOMAXPROCS={{ .GOMAXPROCS }}
+{{ if .GOMAXPROCS }}GOMAXPROCS={{ .GOMAXPROCS }}{{ end }}
 {{ if .EnableV2 }}ETCD_ENABLE_V2={{ .EnableV2 }}{{ end }}
 
 # Logging configuration

--- a/service/testdata/buildenvironment/complex/want.txt
+++ b/service/testdata/buildenvironment/complex/want.txt
@@ -26,7 +26,7 @@ ETCD_TRUSTED_CA_FILE=ca.crt
 # Other
 ETCD_DATA_DIR=/data
 ETCD_STRICT_RECONFIG_CHECK=true
-GOMAXPROCS=0
+
 ETCD_ENABLE_V2=false
 
 # Logging configuration

--- a/service/testdata/buildenvironment/simple/want.txt
+++ b/service/testdata/buildenvironment/simple/want.txt
@@ -26,7 +26,7 @@ ETCD_TRUSTED_CA_FILE=ca.crt
 # Other
 ETCD_DATA_DIR=/data
 ETCD_STRICT_RECONFIG_CHECK=true
-GOMAXPROCS=0
+
 
 
 # Logging configuration


### PR DESCRIPTION
A zero value doesn't do anything anyway, and this helps strict
convergence with etcdadm & etcd-manager (it is one of the few flag
differences).