### PR TITLE
environment: ignore empty lines when converting to map

### DIFF
--- a/service/diff.go
+++ b/service/diff.go
@@ -131,6 +131,10 @@ func makeEnvironment(r io.Reader) (map[string]string, error) {
 			// Ignore comments
 			continue
 		}
+		if strings.TrimSpace(l) == "" {
+			// Ignore empty line
+			continue
+		}
 		// Capture values with embedded '='
 		kv := strings.SplitN(l, "=", 2)
 		var k, v string


### PR DESCRIPTION
Otherwise we get a spurious empty key/value pair in the map.