### PR TITLE
testing: fix race stopping state machine vs stopping etcd

### DIFF
--- a/etcd-manager/test/integration/harness/node.go
+++ b/etcd-manager/test/integration/harness/node.go
@@ -255,15 +255,18 @@ func (n *TestHarnessNode) NewClient() (*etcdclient.EtcdClient, error) {
 }
 
 func (n *TestHarnessNode) Close() error {
+	// Stop the node state machine by cancelling the context
+	// (we do this before stopping etcd, so it won't try to restart etcd)
+	if n.ctxCancel != nil {
+		n.ctxCancel()
+		n.ctxCancel = nil
+	}
+	// Stop etcd
 	if n.etcdServer != nil {
 		_, err := n.etcdServer.StopEtcdProcessForTest()
 		if err != nil {
 			return err
 		}
-	}
-	if n.ctxCancel != nil {
-		n.ctxCancel()
-		n.ctxCancel = nil
 	}
 	return nil
 }


### PR DESCRIPTION
We were stopping etcd first, then stopping the state machine which can
relaunch etcd.  Thus there was a risk that the state machine would
relaunch etcd.  This sometimes manifested itself as a failure to
cleanup test directories.