### PR TITLE
Flags for etcd data dir and kubelet podspec dir

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -56,6 +56,7 @@ type EtcdAdmConfig struct {
 	DataDir    string
 	InstallDir string
 	CacheDir   string
+	PodSpecDir string
 
 	BindAddr string
 
@@ -209,7 +210,6 @@ func SetDownloadDynamicDefaults(cfg *EtcdAdmConfig) error {
 
 // SetDefaults sets configuration values defined at build time
 func SetDefaults(cfg *EtcdAdmConfig) {
-	cfg.DataDir = constants.DefaultDataDir
 	cfg.UnitFile = constants.UnitFile
 	cfg.EnvironmentFile = constants.EnvironmentFile
 	cfg.EtcdctlEnvFile = constants.EtcdctlEnvFile

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,6 +51,8 @@ func init() {
 	initCmd.PersistentFlags().StringArrayVar(&etcdAdmConfig.EtcdDiskPriorities, "disk-priorities", constants.DefaultEtcdDiskPriorities, "Setting etcd disk priority")
 	initCmd.PersistentFlags().StringVar((*string)(&etcdAdmConfig.InitSystem), "init-system", string(apis.Systemd), "init system type (systemd or kubelet)")
 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.DataDir, "data-dir", constants.DefaultDataDir, "etcd data directory")
+	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.PodSpecDir, "kubelet-pod-manifest-path", constants.DefaultPodSpecDir, "kubelet podspec directory")
 
 	runner.registerPhasesAsSubcommands(initCmd)
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -50,6 +50,8 @@ func init() {
 	joinCmd.PersistentFlags().BoolVar(&etcdAdmConfig.Retry, "retry", true, "Enable or disable backoff retry when join etcd member to cluster")
 	joinCmd.PersistentFlags().StringVar((*string)(&etcdAdmConfig.InitSystem), "init-system", string(apis.Systemd), "init system type (systemd or kubelet)")
 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.DataDir, "data-dir", constants.DefaultDataDir, "etcd data directory")
+	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.PodSpecDir, "kubelet-pod-manifest-path", constants.DefaultPodSpecDir, "kubelet podspec directory")
 
 	runner.registerPhasesAsSubcommands(joinCmd)
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -31,7 +31,8 @@ const (
 	EnvironmentFile = "/etc/etcd/etcd.env"
 	EtcdctlEnvFile  = "/etc/etcd/etcdctl.env"
 
-	DefaultDataDir = "/var/lib/etcd"
+	DefaultDataDir    = "/var/lib/etcd"
+	DefaultPodSpecDir = "/etc/kubernetes/manifests"
 
 	DefaultLoopbackHost = "127.0.0.1"
 	DefaultPeerPort     = 2380

--- a/initsystem/kubelet/initsystem.go
+++ b/initsystem/kubelet/initsystem.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -105,7 +106,7 @@ func (s *InitSystem) IsActive() (bool, error) {
 
 func (s *InitSystem) podFile(cfg *apis.EtcdAdmConfig) string {
 	name := s.name(cfg)
-	return "/etc/kubernetes/manifests/" + name + ".manifest"
+	return filepath.Join(s.desiredConfig.PodSpecDir, name+".manifest")
 }
 
 func (s *InitSystem) name(cfg *apis.EtcdAdmConfig) string {


### PR DESCRIPTION
Makes etcd data directory and kubelet podspec directory configurable through flags for `init` and `join` commands.
Both are optional and default to the same values as we currently use.