### PR TITLE
Fix ipv6 detection

### DIFF
--- a/etcd-manager/pkg/volumes/aws/discovery.go
+++ b/etcd-manager/pkg/volumes/aws/discovery.go
@@ -18,7 +18,6 @@ package aws
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -71,7 +70,7 @@ func (a *AWSVolumes) Poll() (map[string]discovery.Node, error) {
 					ID: volume.EtcdName,
 				}
 
-				if strings.HasPrefix(*instance.PrivateDnsName, "i-") {
+				if instance.Ipv6Address != nil {
 					ip := *instance.Ipv6Address
 					node.Endpoints = append(node.Endpoints, discovery.NodeEndpoint{IP: ip})
 				} else {

--- a/etcd-manager/pkg/volumes/aws/volumes.go
+++ b/etcd-manager/pkg/volumes/aws/volumes.go
@@ -103,13 +103,10 @@ func NewAWSVolumes(clusterName string, volumeTags []string, nameTag string) (*AW
 		return nil, fmt.Errorf("error querying ec2 metadata service (for instance-id): %v", err)
 	}
 
-	hostnameBytes, err := a.metadata.GetMetadata("local-hostname")
-	hostname := string(hostnameBytes)
-	if strings.HasPrefix(hostname, "i-") {
-		a.localIP, err = a.metadata.GetMetadata("ipv6")
-		if err != nil {
-			return nil, fmt.Errorf("error querying ec2 metadata service (ipv6): %v", err)
-		}
+	a.localIP, err = a.metadata.GetMetadata("ipv6")
+	awsErr, isAWSErr := err.(awserr.RequestFailure)
+	if !isAWSErr || awsErr.StatusCode() != 404 {
+		return nil, fmt.Errorf("error querying ec2 metadata service (ipv6): %v", err)
 	} else {
 		a.localIP, err = a.metadata.GetMetadata("local-ipv4")
 		if err != nil {


### PR DESCRIPTION
etcd-manager assumed RBN implied IPv6, but that is not the case. Now it will actually check for an ipv6 address.

Kops-related note: This bug does not affect kops 1.22, which does not use RBN at all. But it will affect 1.23+.