### PR TITLE
`make container-build` support GOPROXY env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO_IMAGE ?= golang:1.16
 default: $(BIN)
 
 container-build:
-	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE}  -e GOPROXY=$(GOPROXY) -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make"
+	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE}  -e GOPROXY -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make"
 
 $(BIN):
 	GO111MODULE=on go build -ldflags "$(LDFLAGS)"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO_IMAGE ?= golang:1.16
 default: $(BIN)
 
 container-build:
-	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE} -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make"
+	docker run --rm -e VERSION_OVERRIDE=${VERSION_OVERRIDE}  -e GOPROXY=$(GOPROXY) -v $(PWD):$(PACKAGE_GOPATH) -w $(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) ${GO_IMAGE} /bin/bash -c "make"
 
 $(BIN):
 	GO111MODULE=on go build -ldflags "$(LDFLAGS)"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ For major project goals, see the [roadmap](ROADMAP.md)
    ```
    make container-build
    ```
+   `GOPROXY` env will be inherited:
+   ```
+   GOPROXY=https://goproxy.io make container-build
+   ```
 
 ### Creating a new cluster
 


### PR DESCRIPTION
Related issue: #295 

1. Modify makefile to support GOPROXY on `container-build` command
2. Add `GOPROXY` use case in README