### PR TITLE
Allow using multiple endpoints for etcd client

### DIFF
--- a/apis/config.go
+++ b/apis/config.go
@@ -107,8 +107,8 @@ type EtcdAdmConfig struct {
 
 	// EnableV2 configures whether the V2 client handler is configured, mapping to the --enable-v2 flag
 	// This is a bool, but we use a string because the default value changes across versions.
-	EnableV2 string
-	Endpoint string
+	EnableV2  string
+	Endpoints []string
 }
 
 // InitSystem represents the different types of init system

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -38,7 +38,7 @@ var infoCmd = &cobra.Command{
 			log.Fatalf("[defaults] Error: %s", err)
 		}
 
-		client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
+		client, err := etcd.ClientForEndpoints([]string{etcdAdmConfig.LoopbackClientURL.String()}, &etcdAdmConfig)
 		if err != nil {
 			log.Fatalf("[membership] Error requesting member information: %s", err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -201,7 +201,7 @@ func healthcheck() phase {
 		phaseName: "health",
 		runFunc: func(in *phaseInput) error {
 			log.Println("[health] Checking local etcd endpoint health")
-			client, err := etcd.ClientForEndpoint(in.etcdAdmConfig.LoopbackClientURL.String(), in.etcdAdmConfig)
+			client, err := etcd.ClientForEndpoints([]string{in.etcdAdmConfig.LoopbackClientURL.String()}, in.etcdAdmConfig)
 			if err != nil {
 				return fmt.Errorf("error creating health endpoint client: %w", err)
 			}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -62,7 +62,7 @@ var resetCmd = &cobra.Command{
 			if !skipRemoveMember {
 				var localMember *etcdserverpb.Member
 				log.Println("[membership] Checking if this member was removed")
-				client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
+				client, err := etcd.ClientForEndpoints([]string{etcdAdmConfig.LoopbackClientURL.String()}, &etcdAdmConfig)
 				if err != nil {
 					log.Fatalf("[membership] Error checking membership: %v", err)
 				}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/etcdadm/apis"
 )
 
-// ClientForEndpoint returns an etcd client that will use the given etcd endpoint.
-func ClientForEndpoint(endpoint string, cfg *apis.EtcdAdmConfig) (*clientv3.Client, error) {
+// ClientForEndpoints returns an etcd client that will use the given etcd endpoints.
+func ClientForEndpoints(endpoints []string, cfg *apis.EtcdAdmConfig) (*clientv3.Client, error) {
 	tlsInfo := transport.TLSInfo{
 		CertFile:      cfg.EtcdctlCertFile,
 		KeyFile:       cfg.EtcdctlKeyFile,
@@ -42,7 +42,7 @@ func ClientForEndpoint(endpoint string, cfg *apis.EtcdAdmConfig) (*clientv3.Clie
 	}
 
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   []string{endpoint},
+		Endpoints:   endpoints,
 		DialTimeout: 5 * time.Second,
 		TLS:         tlsConfig,
 	})


### PR DESCRIPTION
The etcdadm init command creates a single member etcd cluster. Other
members can be added to the cluster using the etcdadm join command with
the endpoint of the first member.
If this first member gets deleted, we need to decide on a different endpoint
to be used for the join command for future members. Instead, once the
cluster is created, we should be able to use endpoints of all members with the
join command.
This endpoint only gets used to create an etcd client for listing/adding members.
This commit modifies the ClientForEndpoint method to use all
endpoints that are passed in. This way the etcdadm join command can accept
a comma separated list of etcd members.