### PR TITLE
Set ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK for etcd 3.5.x

### DIFF
--- a/etcd-manager/pkg/etcd/BUILD.bazel
+++ b/etcd-manager/pkg/etcd/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/pki",
         "//pkg/privateapi",
         "//pkg/urls",
+        "//vendor/github.com/blang/semver/v4:semver",
         "//vendor/github.com/golang/protobuf/proto",
         "//vendor/golang.org/x/net/context",
         "//vendor/k8s.io/client-go/util/cert",


### PR DESCRIPTION
This is the recomended mitigation for the 3.5 series, and is planned
to be the default in 3.6
