### PR TITLE
Use EtcdVersionForRestore in backuprestore test

### DIFF
--- a/etcd-manager/test/integration/backuprestore/backuprestore_test.go
+++ b/etcd-manager/test/integration/backuprestore/backuprestore_test.go
@@ -30,33 +30,39 @@ import (
 )
 
 func TestBackupRestore(t *testing.T) {
-	for _, etcdVersion := range etcdversions.AllEtcdVersions {
-		t.Run("etcdVersion="+etcdVersion, func(t *testing.T) {
+	for _, backupEtcdVersion := range etcdversions.AllEtcdVersions {
+		restoreEtcdVersion := etcdversions.EtcdVersionForRestore(backupEtcdVersion)
+		t.Run("backupEtcdVersion="+backupEtcdVersion+"/restoreEtcdVersion="+restoreEtcdVersion, func(t *testing.T) {
 			ctx := context.TODO()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			clusterSpec := &protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: etcdVersion}
-
+			// Create a new cluster
+			backupClusterSpec := &protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: backupEtcdVersion}
 			h1 := harness.NewTestHarness(t, ctx)
 			// Very short backup interval so we don't have to wait too long for a backup!
 			h1.BackupInterval = 5 * time.Second
-			h1.SeedNewCluster(clusterSpec)
+			h1.SeedNewCluster(backupClusterSpec)
 			defer h1.Close()
 
 			n1 := h1.NewNode("127.0.0.1")
+			defer n1.Close()
+
+			klog.Infof("Starting backup node %v with etcd version %q", n1.Address, backupClusterSpec.EtcdVersion)
 			go n1.Run()
 
 			n1.WaitForListMembers(20 * time.Second)
 
-			key := "/testing/backuprestore_" + etcdVersion
-			value := "world-" + etcdVersion
+			key := "/testing/backuprestore_" + backupEtcdVersion
+			value := "world-" + backupEtcdVersion
 
+			klog.Infof("Writing key %q=%q to backup node", key, value)
 			err := n1.Put(ctx, key, value)
 			if err != nil {
 				t.Fatalf("error writing key %q: %v", key, err)
 			}
 
+			klog.Infof("Reading key %q from backup node", key)
 			{
 				actual, err := n1.GetQuorum(ctx, key)
 				if err != nil {
@@ -65,24 +71,27 @@ func TestBackupRestore(t *testing.T) {
 				if actual != value {
 					t.Fatalf("could not read back key %q: %q vs %q", key, actual, value)
 				}
+				klog.Infof("Found key %q with value %q in backup", key, value)
 			}
 
+			klog.Infof("Waiting for backup")
 			h1.WaitForBackup(t, 5*time.Minute)
 
 			// We should be able to shut down the node, delete the local etcd data, and it should do a restore
+			klog.Infof("Stopping backup node %v", n1.Address)
 			if err := n1.Close(); err != nil {
-				t.Fatalf("failed to stop node 1: %v", err)
+				t.Fatalf("failed to stop backup node: %v", err)
 			}
-
-			klog.Infof("removing directory %q", n1.NodeDir)
+			klog.Infof("Removing backup node directory %q", n1.NodeDir)
 			if err := os.RemoveAll(n1.NodeDir); err != nil {
-				t.Fatalf("failed to delete dir for node 1: %v", err)
+				t.Fatalf("failed to delete dir for backup node: %v", err)
 			}
 
 			// Create a new cluster, but reuse the backups
+			restoreClusterSpec := &protoetcd.ClusterSpec{MemberCount: 1, EtcdVersion: restoreEtcdVersion}
 			h2 := harness.NewTestHarness(t, ctx)
 			h2.BackupStorePath = h1.BackupStorePath
-			h2.SeedNewCluster(clusterSpec)
+			h2.SeedNewCluster(restoreClusterSpec)
 			defer h2.Close()
 
 			backupStore, err := backup.NewStore(h2.BackupStorePath)
@@ -100,11 +109,11 @@ func TestBackupRestore(t *testing.T) {
 
 			// We also have to send a restore backup command for a full DR (no common data) scenario
 			backupName := backups[len(backups)-1]
-			klog.Infof("adding command to restore backup %q", backupName)
+			klog.Infof("Adding command to restore backup %q", backupName)
 			h2.AddCommand(&protoetcd.Command{
 				Timestamp: time.Now().UnixNano(),
 				RestoreBackup: &protoetcd.RestoreBackupCommand{
-					ClusterSpec: clusterSpec,
+					ClusterSpec: restoreClusterSpec,
 					Backup:      backupName,
 				},
 			})
@@ -112,12 +121,12 @@ func TestBackupRestore(t *testing.T) {
 			n2 := h2.NewNode("127.0.0.2")
 			defer n2.Close()
 
-			klog.Infof("starting node %v", n2.Address)
+			klog.Infof("Starting restore node %v with etcd version %q", n2.Address, restoreClusterSpec.EtcdVersion)
 			go n2.Run()
 
 			n2.WaitForListMembers(20 * time.Second)
 
-			klog.Infof("checking for key %q", key)
+			klog.Infof("Reading key %q from restore node", key)
 			{
 				actual, err := n2.GetQuorum(ctx, key)
 				if err != nil {
@@ -126,11 +135,12 @@ func TestBackupRestore(t *testing.T) {
 				if actual != value {
 					t.Fatalf("could not reread key %q: %q vs %q", key, actual, value)
 				}
+				klog.Infof("Found key %q with value %q in backup", key, value)
 			}
 
-			klog.Infof("stopping node 2")
+			klog.Infof("Stopping restore node %v", n2.Address)
 			if err := n2.Close(); err != nil {
-				t.Fatalf("failed to stop node 2: %v", err)
+				t.Fatalf("failed to stop restore node: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
This makes the test similar to what `etcd-manager` does during the restore operation:
https://github.com/kubernetes-sigs/etcdadm/blob/f9a20374ca1abc9a6083e6db21aeaa32e2560504/etcd-manager/pkg/etcd/restore.go#L125-L133
```
cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.0/restoreEtcdVersion=3.5.4" in /tmp/1003361396
backuprestore_test.go:51] Starting backup node 127.0.0.1 with etcd version "3.5.0"
backuprestore_test.go:59] Writing key "/testing/backuprestore_3.5.0"="world-3.5.0" to backup node
backuprestore_test.go:65] Reading key "/testing/backuprestore_3.5.0" from backup node
backuprestore_test.go:74] Found key "/testing/backuprestore_3.5.0" with value "world-3.5.0" in backup
backuprestore_test.go:77] Waiting for backup
backuprestore_test.go:81] Stopping backup node 127.0.0.1
backuprestore_test.go:85] Removing backup node directory "/tmp/1003361396/testharnesscluster/nodes/127.0.0.1"
cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.0/restoreEtcdVersion=3.5.4" in /tmp/1340905303
backuprestore_test.go:112] Adding command to restore backup "2022-05-01T09:22:49Z-000026"
backuprestore_test.go:124] Starting restore node 127.0.0.2 with etcd version "3.5.4"
backuprestore_test.go:129] Reading key "/testing/backuprestore_3.5.0" from restore node
backuprestore_test.go:138] Found key "/testing/backuprestore_3.5.0" with value "world-3.5.0" in backup
backuprestore_test.go:141] Stopping restore node 127.0.0.2

cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.1/restoreEtcdVersion=3.5.4" in /tmp/2940031322
backuprestore_test.go:51] Starting backup node 127.0.0.1 with etcd version "3.5.1"
backuprestore_test.go:59] Writing key "/testing/backuprestore_3.5.1"="world-3.5.1" to backup node
backuprestore_test.go:65] Reading key "/testing/backuprestore_3.5.1" from backup node
backuprestore_test.go:74] Found key "/testing/backuprestore_3.5.1" with value "world-3.5.1" in backup
backuprestore_test.go:77] Waiting for backup
backuprestore_test.go:81] Stopping backup node 127.0.0.1
backuprestore_test.go:85] Removing backup node directory "/tmp/2940031322/testharnesscluster/nodes/127.0.0.1"
cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.1/restoreEtcdVersion=3.5.4" in /tmp/3288148461
backuprestore_test.go:112] Adding command to restore backup "2022-05-01T09:23:13Z-000029"
backuprestore_test.go:124] Starting restore node 127.0.0.2 with etcd version "3.5.4"
backuprestore_test.go:129] Reading key "/testing/backuprestore_3.5.1" from restore node
backuprestore_test.go:138] Found key "/testing/backuprestore_3.5.1" with value "world-3.5.1" in backup
backuprestore_test.go:141] Stopping restore node 127.0.0.2

cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.3/restoreEtcdVersion=3.5.4" in /tmp/4277173945
backuprestore_test.go:51] Starting backup node 127.0.0.1 with etcd version "3.5.3"
backuprestore_test.go:59] Writing key "/testing/backuprestore_3.5.3"="world-3.5.3" to backup node
backuprestore_test.go:65] Reading key "/testing/backuprestore_3.5.3" from backup node
backuprestore_test.go:74] Found key "/testing/backuprestore_3.5.3" with value "world-3.5.3" in backup
backuprestore_test.go:77] Waiting for backup
backuprestore_test.go:81] Stopping backup node 127.0.0.1
backuprestore_test.go:85] Removing backup node directory "/tmp/4277173945/testharnesscluster/nodes/127.0.0.1"
cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.3/restoreEtcdVersion=3.5.4" in /tmp/2991766112
backuprestore_test.go:112] Adding command to restore backup "2022-05-01T09:23:36Z-000032"
backuprestore_test.go:124] Starting restore node 127.0.0.2 with etcd version "3.5.4"
backuprestore_test.go:129] Reading key "/testing/backuprestore_3.5.3" from restore node
backuprestore_test.go:138] Found key "/testing/backuprestore_3.5.3" with value "world-3.5.3" in backup
backuprestore_test.go:141] Stopping restore node 127.0.0.2

cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.4/restoreEtcdVersion=3.5.4" in /tmp/487675563
backuprestore_test.go:51] Starting backup node 127.0.0.1 with etcd version "3.5.4"
backuprestore_test.go:59] Writing key "/testing/backuprestore_3.5.4"="world-3.5.4" to backup node
backuprestore_test.go:65] Reading key "/testing/backuprestore_3.5.4" from backup node
backuprestore_test.go:74] Found key "/testing/backuprestore_3.5.4" with value "world-3.5.4" in backup
backuprestore_test.go:77] Waiting for backup
backuprestore_test.go:81] Stopping backup node 127.0.0.1
backuprestore_test.go:85] Removing backup node directory "/tmp/487675563/testharnesscluster/nodes/127.0.0.1"
cluster.go:67] Starting new testharness for "TestBackupRestore/backupEtcdVersion=3.5.4/restoreEtcdVersion=3.5.4" in /tmp/2252333096
backuprestore_test.go:112] Adding command to restore backup "2022-05-01T09:24:03Z-000035"
backuprestore_test.go:124] Starting restore node 127.0.0.2 with etcd version "3.5.4"
backuprestore_test.go:129] Reading key "/testing/backuprestore_3.5.4" from restore node
backuprestore_test.go:138] Found key "/testing/backuprestore_3.5.4" with value "world-3.5.4" in backup
backuprestore_test.go:141] Stopping restore node 127.0.0.2
```