### PR TITLE
Fix reattachment of volumes for Hetzner

### DIFF
--- a/etcd-manager/pkg/volumes/hetzner/volumes.go
+++ b/etcd-manager/pkg/volumes/hetzner/volumes.go
@@ -141,7 +141,9 @@ func (a *HetznerVolumes) FindVolumes() ([]*volumes.Volume, error) {
 
 		if volume.Server != nil {
 			localEtcdVolume.AttachedTo = strconv.Itoa(volume.Server.ID)
-			localEtcdVolume.LocalDevice = fmt.Sprintf("%s%d", localDevicePrefix, volume.ID)
+			if volume.Server.ID == a.server.ID {
+				localEtcdVolume.LocalDevice = fmt.Sprintf("%s%d", localDevicePrefix, volume.ID)
+			}
 		}
 
 		localEtcdVolumes = append(localEtcdVolumes, localEtcdVolume)


### PR DESCRIPTION
If `volume.LocalDevice` is set etcd-manager will consider that the volume is mounted to the current server:
https://github.com/kubernetes-sigs/etcdadm/blob/7b9d5aafe83d5f94e37f00111b29b61d1800004c/etcd-manager/pkg/volumes/mounter.go#L299-L302