### PR TITLE
Use volume name tag to match the instance group for Hetzner

### DIFF
--- a/etcd-manager/pkg/volumes/hetzner/discovery.go
+++ b/etcd-manager/pkg/volumes/hetzner/discovery.go
@@ -32,13 +32,13 @@ var _ discovery.Interface = &HetznerVolumes{}
 func (a *HetznerVolumes) Poll() (map[string]discovery.Node, error) {
 	peers := make(map[string]discovery.Node)
 
-	klog.V(2).Infof("Discovering volumes for %q", a.nameTag)
-	etcdVolumes, err := getMatchingVolumes(a.hcloudClient, a.matchTags)
+	klog.V(2).Infof("Discovering peers with volumes matching labels: %v", a.matchPeerTags)
+	matchingVolumes, err := getMatchingVolumes(a.hcloudClient, a.matchPeerTags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get matching volumes: %w", err)
 	}
 
-	for _, volume := range etcdVolumes {
+	for _, volume := range matchingVolumes {
 		if volume.Server == nil {
 			// Volume doesn't have a server attached yet
 			continue

--- a/etcd-manager/pkg/volumes/hetzner/volumes.go
+++ b/etcd-manager/pkg/volumes/hetzner/volumes.go
@@ -38,8 +38,9 @@ const (
 // HetznerVolumes defines the Hetzner Cloud volume implementation.
 type HetznerVolumes struct {
 	clusterName string
-	matchTags   map[string]string
-	nameTag     string
+
+	matchPeerTags map[string]string
+	matchNameTags map[string]string
 
 	hcloudClient *hcloud.Client
 	server       *hcloud.Server
@@ -51,7 +52,7 @@ var _ volumes.Volumes = &HetznerVolumes{}
 func NewHetznerVolumes(clusterName string, volumeTags []string, nameTag string) (*HetznerVolumes, error) {
 	serverID, err := metadata.NewClient().InstanceID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve server id: %s", err)
+		return nil, fmt.Errorf("failed to retrieve server id: %w", err)
 	}
 	klog.V(2).Infof("Found ID of the running server: %d", serverID)
 
@@ -66,7 +67,7 @@ func NewHetznerVolumes(clusterName string, volumeTags []string, nameTag string) 
 
 	server, _, err := hcloudClient.Server.GetByID(context.TODO(), serverID)
 	if err != nil || server == nil {
-		return nil, fmt.Errorf("failed to get info for the running server: %s", err)
+		return nil, fmt.Errorf("failed to get info for the running server: %w", err)
 	}
 
 	klog.V(2).Infof("Found name of the running server: %q", server.Name)
@@ -82,19 +83,30 @@ func NewHetznerVolumes(clusterName string, volumeTags []string, nameTag string) 
 	}
 
 	a := &HetznerVolumes{
-		clusterName:  clusterName,
-		matchTags:    make(map[string]string),
-		nameTag:      nameTag,
-		hcloudClient: hcloudClient,
-		server:       server,
+		clusterName:   clusterName,
+		matchPeerTags: make(map[string]string),
+		matchNameTags: make(map[string]string),
+		hcloudClient:  hcloudClient,
+		server:        server,
 	}
 
 	for _, volumeTag := range volumeTags {
 		tokens := strings.SplitN(volumeTag, "=", 2)
 		if len(tokens) == 1 {
-			a.matchTags[tokens[0]] = ""
+			a.matchPeerTags[tokens[0]] = ""
+			a.matchNameTags[tokens[0]] = ""
 		} else {
-			a.matchTags[tokens[0]] = tokens[1]
+			a.matchPeerTags[tokens[0]] = tokens[1]
+			a.matchNameTags[tokens[0]] = tokens[1]
+		}
+	}
+
+	{
+		tokens := strings.SplitN(nameTag, "=", 2)
+		if len(tokens) == 1 {
+			a.matchNameTags[tokens[0]] = ""
+		} else {
+			a.matchNameTags[tokens[0]] = tokens[1]
 		}
 	}
 
@@ -110,16 +122,16 @@ func (a *HetznerVolumes) FindVolumes() ([]*volumes.Volume, error) {
 	}
 	serverLocation := a.server.Datacenter.Location.Name
 
-	allEtcdVolumes, err := getMatchingVolumes(a.hcloudClient, a.matchTags)
+	matchingVolumes, err := getMatchingVolumes(a.hcloudClient, a.matchNameTags)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get matching volumes: %s", err)
+		return nil, fmt.Errorf("failed to get matching volumes: %w", err)
 	}
 
 	var localEtcdVolumes []*volumes.Volume
-	for _, volume := range allEtcdVolumes {
+	for _, volume := range matchingVolumes {
 		// Only volumes from the same location can be mounted
 		if volume.Location == nil {
-			klog.Warningf("failed to find volume location for %s(%d)", volume.Name, volume.ID)
+			klog.Warningf("failed to find volume %s(%d) location", volume.Name, volume.ID)
 			continue
 		}
 		volumeLocation := volume.Location.Name
@@ -164,7 +176,7 @@ func (a *HetznerVolumes) FindMountedVolume(volume *volumes.Volume) (string, erro
 	}
 
 	if !os.IsNotExist(err) {
-		return "", fmt.Errorf("failed to find local device %q: %v", device, err)
+		return "", fmt.Errorf("failed to find local device %q: %w", device, err)
 	}
 
 	// When not found, the interface says to return ("", nil)


### PR DESCRIPTION
Goes together with https://github.com/kubernetes/kops/pull/14181.

```sh
$ hcloud volume list -o columns=name,server -s name 
NAME                                       SERVER
etcd-1.etcd-events.test1.k8s.local         master-fsn1-1-572f678e19233740
etcd-1.etcd-main.test1.k8s.local           master-fsn1-1-572f678e19233740
etcd-2.etcd-events.test1.k8s.local         master-fsn1-2-35d166ac6dc945b1
etcd-2.etcd-main.test1.k8s.local           master-fsn1-2-35d166ac6dc945b1
etcd-3.etcd-events.test1.k8s.local         master-fsn1-3-7af95061338a68fd
etcd-3.etcd-main.test1.k8s.local           master-fsn1-3-7af95061338a68fd
```

/hold for feedback
/cc @justinsb @olemarkus 