### PR TITLE
Restart the server using the recommended etcd version

### DIFF
--- a/etcd-manager/test/integration/resize_cluster_test.go
+++ b/etcd-manager/test/integration/resize_cluster_test.go
@@ -61,7 +61,7 @@ func TestResizeCluster(t *testing.T) {
 					t.Fatalf("unable to set test key: %v", err)
 				}
 
-				n1.AssertVersion(t, etcdVersion)
+				n1.AssertVersion(t, etcdversions.EtcdVersionForAdoption(etcdVersion))
 			}
 
 			n2 := h.NewNode("127.0.0.2")
@@ -107,9 +107,9 @@ func TestResizeCluster(t *testing.T) {
 					t.Fatalf("unexpected test key value after upgrade: %q", v)
 				}
 
-				n1.AssertVersion(t, etcdVersion)
-				n2.AssertVersion(t, etcdVersion)
-				n3.AssertVersion(t, etcdVersion)
+				n1.AssertVersion(t, etcdversions.EtcdVersionForAdoption(etcdVersion))
+				n2.AssertVersion(t, etcdversions.EtcdVersionForAdoption(etcdVersion))
+				n3.AssertVersion(t, etcdversions.EtcdVersionForAdoption(etcdVersion))
 			}
 
 			cancel()


### PR DESCRIPTION
When re-starting after an upgrade, `etcd-manager` tries to use the version of `etcd` from the state. This makes it impossible for us to remove any unused `etcd` versions from the bundle, even if there is a newer patch version that should be used instead.

Same approach as when restoring from backup:
https://github.com/kubernetes-sigs/etcdadm/blob/f9a20374ca1abc9a6083e6db21aeaa32e2560504/etcd-manager/pkg/etcd/restore.go#L125-L138

/cc @justinsb @olemarkus 