### PR TITLE
Trim the os and arch suffix from bin dir name

### DIFF
--- a/etcd-manager/images/BUILD
+++ b/etcd-manager/images/BUILD
@@ -6,7 +6,7 @@ load(
     "container_layer",
     "container_push",
 )
-load("etcd.bzl", "supported_etcd_arch_and_version")
+load(":etcd.bzl", "supported_etcd_arch_and_version")
 
 # Layer for etcd 3.1.12, as used in k8s 1.10
 # Layer for etcd 3.2.18, as originally used in k8s 1.11
@@ -27,8 +27,7 @@ load("etcd.bzl", "supported_etcd_arch_and_version")
             arch = arch,
             version = version,
         ),
-        directory = "/opt/etcd-v{version}-linux-{arch}/".format(
-            arch = arch,
+        directory = "/opt/etcd-v{version}/".format(
             version = version,
         ),
         files = [

--- a/etcd-manager/pkg/etcd/etcdprocess.go
+++ b/etcd-manager/pkg/etcd/etcdprocess.go
@@ -155,7 +155,7 @@ func BindirForEtcdVersion(etcdVersion string, cmd string) (string, error) {
 
 	var binDirs []string
 	for _, baseDir := range baseDirs {
-		binDir := filepath.Join(baseDir, "etcd-"+etcdVersion+"-"+runtime.GOOS+"-"+runtime.GOARCH)
+		binDir := filepath.Join(baseDir, "etcd-"+etcdVersion)
 		binDirs = append(binDirs, binDir)
 	}
 
@@ -163,7 +163,10 @@ func BindirForEtcdVersion(etcdVersion string, cmd string) (string, error) {
 		for _, baseDir := range baseDirs {
 			platform := "linux_amd64_stripped"
 
-			binDir := filepath.Join(baseDir, "external", "etcd_"+strings.Replace(etcdVersion, ".", "_", -1)+"_source", platform)
+			var binDir string
+			binDir = filepath.Join(baseDir, "etcd-"+etcdVersion+"-"+runtime.GOOS+"-"+runtime.GOARCH)
+			binDirs = append(binDirs, binDir)
+			binDir = filepath.Join(baseDir, "external", "etcd_"+strings.Replace(etcdVersion, ".", "_", -1)+"_source", platform)
 			binDirs = append(binDirs, binDir)
 			binDir = filepath.Join(baseDir, "external", "etcd_"+strings.Replace(etcdVersion, ".", "_", -1)+"_source", cmd, platform)
 			binDirs = append(binDirs, binDir)


### PR DESCRIPTION
Having bin dirs like `"/opt/etcd-"+etcdVersion+"-"+runtime.GOOS+"-"+runtime.GOARCH` doesn't add any extra value these days, considering we have multi-arch images. It actually makes features like https://github.com/kubernetes/kops/pull/14785 harder to implement.