### PR TITLE
Build slim etcd-manager image without etcd binaries

### DIFF
--- a/etcd-manager/Makefile
+++ b/etcd-manager/Makefile
@@ -57,6 +57,20 @@ push-etcd-manager-manifest:
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push --purge \
 		$(IMAGE_BASE)etcd-manager:$(STABLE_DOCKER_TAG)
 
+.PHONY: push-etcd-manager-slim
+push-etcd-manager-slim:
+	${BAZEL} run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push-etcd-manager-slim
+	${BAZEL} run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //images:push-etcd-manager-slim
+
+.PHONY: push-etcd-manager-slim-manifest
+push-etcd-manager-slim-manifest:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create \
+		$(IMAGE_BASE)etcd-manager:$(STABLE_DOCKER_TAG)-slim \
+		$(IMAGE_BASE)etcd-manager:$(STABLE_DOCKER_TAG)-slim-amd64 \
+		$(IMAGE_BASE)etcd-manager:$(STABLE_DOCKER_TAG)-slim-arm64
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push --purge \
+		$(IMAGE_BASE)etcd-manager:$(STABLE_DOCKER_TAG)-slim
+
 .PHONY: push-etcd-dump
 push-etcd-dump:
 	${BAZEL} run ${BAZEL_FLAGS} --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //images:push-etcd-dump
@@ -86,11 +100,11 @@ push-etcd-backup-manifest:
 		$(IMAGE_BASE)etcd-backup:$(STABLE_DOCKER_TAG)
 
 .PHONY: push-images
-push-images: push-etcd-manager push-etcd-dump push-etcd-backup
+push-images: push-etcd-manager push-etcd-manager-slim push-etcd-dump push-etcd-backup
 	echo "pushed images"
 
 .PHONY: push-manifests
-push-manifests: push-etcd-manager-manifest push-etcd-dump-manifest push-etcd-backup-manifest
+push-manifests: push-etcd-manager-manifest push-etcd-manager-slim-manifest push-etcd-dump-manifest push-etcd-backup-manifest
 	echo "pushed manifests"
 
 .PHONY: push

--- a/etcd-manager/cloudbuild-master.yaml
+++ b/etcd-manager/cloudbuild-master.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['version']
 
 - name: gcr.io/cloud-builders/bazel
-  args: ['build', '//cmd/...', '//images:etcd-manager', '//images:etcd-backup', '//images:etcd-dump']
+  args: ['build', '//cmd/...', '//images:etcd-manager', '//images:etcd-manager-slim', '//images:etcd-backup', '//images:etcd-dump']
   # To build with GCS cache
   #args: ['build', '--google_default_credentials', '--spawn_strategy=remote', '--genrule_strategy=remote', '--strategy=Javac=remote', '--strategy=Closure=remote', '--remote_http_cache=https://storage.googleapis.com/cache-bucket', '//cmd/...']
 
@@ -12,6 +12,12 @@ steps:
 
 - name: gcr.io/cloud-builders/bazel
   args: ['run', '//images:push-etcd-manager']
+  env:
+  - 'DOCKER_REGISTRY=${_DOCKER_REGISTRY}'
+  - 'DOCKER_IMAGE_PREFIX=${_DOCKER_IMAGE_PREFIX}'
+  - 'DOCKER_TAG=${COMMIT_SHA}'
+- name: gcr.io/cloud-builders/bazel
+  args: ['run', '//images:push-etcd-manager-slim']
   env:
   - 'DOCKER_REGISTRY=${_DOCKER_REGISTRY}'
   - 'DOCKER_IMAGE_PREFIX=${_DOCKER_IMAGE_PREFIX}'

--- a/etcd-manager/cloudbuild.yaml
+++ b/etcd-manager/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 - name: gcr.io/cloud-marketplace-containers/google/bazel:3.5.0
   entrypoint: bazel
-  args: ['build', '//cmd/...', '//images:etcd-manager', '//images:etcd-backup', '//images:etcd-dump']
+  args: ['build', '//cmd/...', '//images:etcd-manager', '//images:etcd-manager-slim', '//images:etcd-backup', '//images:etcd-dump']
   # To build with GCS cache
   #args: ['build', '--google_default_credentials', '--spawn_strategy=remote', '--genrule_strategy=remote', '--strategy=Javac=remote', '--strategy=Closure=remote', '--remote_http_cache=https://storage.googleapis.com/cache-bucket', '//cmd/...']
 

--- a/etcd-manager/images/BUILD
+++ b/etcd-manager/images/BUILD
@@ -105,6 +105,27 @@ container_image(
     ],
 )
 
+container_image(
+    name = "etcd-manager-slim",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:amd64": "amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "arm64",
+    }),
+    base = select({
+        "@io_bazel_rules_go//go/platform:amd64": "//images/base:base_image_amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "//images/base:base_image_arm64",
+    }),
+    entrypoint = ["/etcd-manager"],
+    env = select({
+        "@io_bazel_rules_go//go/platform:amd64": {},
+        "@io_bazel_rules_go//go/platform:arm64": {"ETCD_UNSUPPORTED_ARCH": "arm64"},
+    }),
+    files = [
+        "//cmd/etcd-manager",
+        "//cmd/etcd-manager-ctl",
+    ],
+)
+
 container_push(
     name = "push-etcd-manager",
     format = "Docker",
@@ -114,6 +135,18 @@ container_push(
     tag = select({
         "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_TAG}-amd64",
         "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_TAG}-arm64",
+    }),
+)
+
+container_push(
+    name = "push-etcd-manager-slim",
+    format = "Docker",
+    image = ":etcd-manager-slim",
+    registry = "{STABLE_DOCKER_REGISTRY}",
+    repository = "{STABLE_DOCKER_IMAGE_PREFIX}etcd-manager",
+    tag = select({
+        "@io_bazel_rules_go//go/platform:amd64": "{STABLE_DOCKER_TAG}-slim-amd64",
+        "@io_bazel_rules_go//go/platform:arm64": "{STABLE_DOCKER_TAG}-slim-arm64",
     }),
 )
 


### PR DESCRIPTION
The suffix could be either `slim`, `lite`, or something else entirely.

/cc @justinsb