### PR TITLE
etcdadm: Should close GRPC clients

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -42,6 +42,8 @@ var infoCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("[membership] Error requesting member information: %s", err)
 		}
+		defer client.Close()
+
 		ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
 		mresp, err := client.MemberList(ctx)
 		cancel()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -207,6 +207,8 @@ func healthcheck() phase {
 			if err != nil {
 				return fmt.Errorf("error creating health endpoint client: %w", err)
 			}
+			defer client.Close()
+
 			ctx, cancel := context.WithTimeout(context.Background(), in.initSystem.StartupTimeout())
 			_, err = client.Get(ctx, constants.EtcdHealthCheckKey)
 			cancel()

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -138,6 +138,8 @@ func membership() phase {
 			if err != nil {
 				return fmt.Errorf("error checking membership: %v", err)
 			}
+			defer client.Close()
+
 			ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
 			mresp, err := client.MemberList(ctx)
 			cancel()

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -67,6 +67,8 @@ var resetCmd = &cobra.Command{
 				if err != nil {
 					log.Fatalf("[membership] Error checking membership: %v", err)
 				}
+				defer client.Close()
+
 				ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
 				mresp, err := client.MemberList(ctx)
 				cancel()

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -30,6 +30,7 @@ import (
 )
 
 // ClientForEndpoint returns an etcd client that will use the given etcd endpoint.
+// Callers should Close() the returned connection after use.
 func ClientForEndpoint(endpoint string, cfg *apis.EtcdAdmConfig) (*clientv3.Client, error) {
 	tlsInfo := transport.TLSInfo{
 		CertFile:      cfg.EtcdctlCertFile,


### PR DESCRIPTION
We should be closing these when we are done with the connection,
otherwise we leak goroutines.
