### PR TITLE
Add gsutil when using Cloud Build

### DIFF
--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
   - DOCKER_IMAGE_PREFIX=$_DOCKER_IMAGE_PREFIX
   - ARTIFACT_LOCATION=$_ARTIFACT_LOCATION
   entrypoint: dev/staging/push-etcdadm.sh
-- name: golang:1.19
+- name: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
   env:
   - PULL_BASE_REF=$_PULL_BASE_REF
   # We don't pass version; we want to use our own version tagging from git

--- a/dev/staging/cloudbuild.yaml
+++ b/dev/staging/cloudbuild.yaml
@@ -6,6 +6,7 @@ options:
 
 steps:
 - name: golang:1.19
+  waitFor: ['-']
   env:
   - PULL_BASE_REF=$_PULL_BASE_REF
   - VERSION=$_GIT_TAG
@@ -14,6 +15,7 @@ steps:
   - ARTIFACT_LOCATION=$_ARTIFACT_LOCATION
   entrypoint: dev/staging/push-etcdadm.sh
 - name: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+  waitFor: ['-']
   env:
   - PULL_BASE_REF=$_PULL_BASE_REF
   # We don't pass version; we want to use our own version tagging from git

--- a/dev/staging/push-etcdadm.sh
+++ b/dev/staging/push-etcdadm.sh
@@ -34,6 +34,22 @@ if [[ "${ARTIFACT_LOCATION}" != */ ]]; then
   ARTIFACT_LOCATION="${ARTIFACT_LOCATION}/"
 fi
 
-# Build and upload etcdadm binary
+# Build etcdadm binary
 make etcdadm
+
+# Upload etcdadm binary
+DOWNLOAD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz"
+echo "Downloading google-cloud-sdk.tar.gz from $DOWNLOAD_URL"
+curl -L -o "/tmp/google-cloud-sdk.tar.gz" "${DOWNLOAD_URL}"
+tar xzf /tmp/google-cloud-sdk.tar.gz -C /
+rm /tmp/google-cloud-sdk.tar.gz
+/google-cloud-sdk/install.sh \
+    --bash-completion=false \
+    --usage-reporting=false \
+    --quiet
+ln -s /google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+ln -s /google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
+gcloud info
+gcloud config list
+gcloud auth list
 gsutil -h "Cache-Control:private, max-age=0, no-transform" -m cp -n etcdadm ${ARTIFACT_LOCATION}${VERSION}/etcdadm


### PR DESCRIPTION
Follow-up to #366.

```
Step #0: go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
Step #0: + gsutil -h 'Cache-Control:private, max-age=0, no-transform' -m cp -n etcdadm gs://k8s-staging-etcdadm/ci/builds/v20230206-etcd-managerv3.0.20230201-26-ge6741679/etcdadm
Step #0: dev/staging/push-etcdadm.sh: line 39: gsutil: command not found
Finished Step #0
ERROR
ERROR: build step 0 "golang:1.19" failed: step exited with non-zero status: 127
```