### PR TITLE
Switched from N1 to E2 machine

### DIFF
--- a/etcd-manager/cloudbuild-master.yaml
+++ b/etcd-manager/cloudbuild-master.yaml
@@ -37,4 +37,4 @@ steps:
 
 timeout: 1800s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/etcd-manager/cloudbuild.yaml
+++ b/etcd-manager/cloudbuild.yaml
@@ -15,4 +15,4 @@ steps:
 
 timeout: 3000s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
Reference https://github.com/kubernetes/k8s.io/issues/5059

This changes machine type from N1 to E2 which are newer but almost same pricing. But with E2 being more efficient and overall taking less time. The cost can be reduced.