### PR TITLE
Update to golang 1.19.9

### DIFF
--- a/etcd-manager/WORKSPACE
+++ b/etcd-manager/WORKSPACE
@@ -28,7 +28,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19.5")
+go_register_toolchains(version = "1.19.9")
 
 gazelle_dependencies()
 


### PR DESCRIPTION
No known issues, just to keep scanners from complaining.
