### PR TITLE
remove specific goproxy url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For major project goals, see the [roadmap](ROADMAP.md)
    ```
    `GOPROXY` env will be inherited:
    ```
-   GOPROXY=https://goproxy.io make container-build
+   GOPROXY=${YOUR_GOPROXY_URL} make container-build
    ```
 
 ### Creating a new cluster


### PR DESCRIPTION
As dicussion on https://github.com/kubernetes-sigs/etcdadm/pull/296#issuecomment-1868381803

Remove specific goproxy url for security .